### PR TITLE
nvim: add new BufferChangedTick(nvim_buf_get_changedtick) function

### DIFF
--- a/nvim/apidef.go
+++ b/nvim/apidef.go
@@ -62,6 +62,11 @@ func BufferVar(buffer Buffer, name string) interface{} {
 	name(nvim_buf_get_var)
 }
 
+// BufferChangedTick gets a changed tick of a buffer.
+func BufferChangedTick(buffer Buffer) int {
+	name(nvim_buf_get_changedtick)
+}
+
 // SetBufferVar sets a buffer-scoped (b:) variable.
 func SetBufferVar(buffer Buffer, name string, value interface{}) {
 	name(nvim_buf_set_var)

--- a/nvim/apiimp.go
+++ b/nvim/apiimp.go
@@ -225,6 +225,23 @@ func (p *Pipeline) BufferVar(buffer Buffer, name string, result interface{}) {
 	p.call("nvim_buf_get_var", result, buffer, name)
 }
 
+// BufferChangedTick gets a changed tick of a buffer.
+func (v *Nvim) BufferChangedTick(buffer Buffer) (int, error) {
+	var result int
+	err := v.call("nvim_buf_get_changedtick", &result, buffer)
+	return result, err
+}
+
+// BufferChangedTick gets a changed tick of a buffer.
+func (b *Batch) BufferChangedTick(buffer Buffer, result *int) {
+	b.call("nvim_buf_get_changedtick", result, buffer)
+}
+
+// BufferChangedTick gets a changed tick of a buffer.
+func (p *Pipeline) BufferChangedTick(buffer Buffer, result *int) {
+	p.call("nvim_buf_get_changedtick", result, buffer)
+}
+
 // SetBufferVar sets a buffer-scoped (b:) variable.
 func (v *Nvim) SetBufferVar(buffer Buffer, name string, value interface{}) error {
 	return v.call("nvim_buf_set_var", nil, buffer, name, value)


### PR DESCRIPTION
Neovim has been added new `nvim_buf_get_changedtick` API.

The function's order and godoc comment conformed to Neovim's `api/buffer.c` file.