### PR TITLE
nvim: change get_api_info to new 'nvim_' suffix API

### DIFF
--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -204,7 +204,7 @@ func (v *Nvim) ChannelID() int {
 		ChannelID int `msgpack:",array"`
 		Info      interface{}
 	}
-	if err := v.ep.Call("vim_get_api_info", &info); err != nil {
+	if err := v.ep.Call("nvim_get_api_info", &info); err != nil {
 		// TODO: log error and exit process?
 	}
 	v.channelID = info.ChannelID


### PR DESCRIPTION
Neovim has been deprecated `vim_` suffix API, change to `nvim_` suffix API.