### PR TITLE
nvim: fix Batch.Call to should use the nvim_call_atomic

### DIFF
--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -430,7 +430,7 @@ func (b *Batch) Call(fname string, result interface{}, args ...interface{}) {
 	if args == nil {
 		args = []interface{}{}
 	}
-	b.call("nvim_call_function", result, fname, args)
+	b.call("nvim_call_atomic", result, fname, args)
 }
 
 // decodeExt decodes a MsgPack encoded number to an integer.


### PR DESCRIPTION
Now `Batch.Call` uses `nvim_call_function`, which not atomically. Should use the `nvim_call_atomic`.(?)

But I don't know which is correct, and do not understand all how Neovim's  internal `atomic` behavior. Please code review.