### PR TITLE
hide the nvim exec window for Windows

### DIFF
--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -20,7 +20,9 @@ import (
 	"io"
 	"os/exec"
 	"reflect"
+	"runtime"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/neovim/go-client/msgpack"
@@ -128,6 +130,9 @@ func NewEmbedded(options *EmbedOptions) (*Nvim, error) {
 	cmd := exec.Command(path, append([]string{"--embed"}, options.Args...)...)
 	cmd.Env = options.Env
 	cmd.Dir = options.Dir
+	if runtime.GOOS == "windows" {
+		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
+	}
 
 	inw, err := cmd.StdinPipe()
 	if err != nil {

--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -20,7 +20,6 @@ import (
 	"io"
 	"os/exec"
 	"reflect"
-	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -30,6 +29,8 @@ import (
 )
 
 //go:generate go run apitool.go -generate apiimp.go
+
+var embedProcAttr *syscall.SysProcAttr
 
 // Nvim represents a remote instance of Nvim. It is safe to call Nvim methods
 // concurrently.
@@ -130,9 +131,7 @@ func NewEmbedded(options *EmbedOptions) (*Nvim, error) {
 	cmd := exec.Command(path, append([]string{"--embed"}, options.Args...)...)
 	cmd.Env = options.Env
 	cmd.Dir = options.Dir
-	if runtime.GOOS == "windows" {
-		cmd.SysProcAttr = &syscall.SysProcAttr{HideWindow: true}
-	}
+	cmd.SysProcAttr = embedProcAttr
 
 	inw, err := cmd.StdinPipe()
 	if err != nil {

--- a/nvim/nvim_windows.go
+++ b/nvim/nvim_windows.go
@@ -1,0 +1,7 @@
+package nvim
+
+import "syscall"
+
+func init() {
+	embedProcAttr = &syscall.SysProcAttr{HideWindow: true}
+}


### PR DESCRIPTION
It pops up the console (cmd.exe) for nvim.exe on Windows. This RP to hide the window. 