### PR TITLE
Automatic addition of manifest

### DIFF
--- a/nvim/plugin/main.go
+++ b/nvim/plugin/main.go
@@ -56,7 +56,7 @@ func Main(registerHandlers func(p *Plugin) error) {
 			log.Fatal(err)
 		}
 		if *vimFilePath != "" {
-			if err := replaceManifest(*vimFilePath, *pluginHost, p.Manifest(*pluginHost)); err != nil {
+			if err := overwriteManifest(*vimFilePath, *pluginHost, p.Manifest(*pluginHost)); err != nil {
 				log.Fatal(err)
 			}
 		} else {
@@ -82,16 +82,16 @@ func Main(registerHandlers func(p *Plugin) error) {
 	}
 }
 
-func replaceManifest(path, host string, manifest []byte) error {
+func overwriteManifest(path, host string, manifest []byte) error {
 	input, err := ioutil.ReadFile(path)
 	if err != nil {
 		return err
 	}
-	output := overwriteManifest(host, input, manifest)
+	output := replaceManifest(host, input, manifest)
 	return ioutil.WriteFile(path, output, 0666)
 }
 
-func overwriteManifest(host string, input, manifest []byte) []byte {
+func replaceManifest(host string, input, manifest []byte) []byte {
 	p := regexp.MustCompile(`(?ms)^call remote#host#RegisterPlugin\('` + regexp.QuoteMeta(host) + `'.*?^\\ ]\)\n`)
 	match := p.FindIndex(input)
 	var output []byte

--- a/nvim/plugin/main.go
+++ b/nvim/plugin/main.go
@@ -49,7 +49,7 @@ import (
 // manifest will be automatically written to .vim file.
 func Main(registerHandlers func(p *Plugin) error) {
 	pluginHost := flag.String("manifest", "", "Write plugin manifest for `host` to stdout")
-	vimFilePath := flag.String("location", "", "if this option is enable, manifest is automatically written `.vim file`")
+	vimFilePath := flag.String("location", "", "Manifest is automatically written to `.vim file`")
 	flag.Parse()
 
 	if *pluginHost != "" {

--- a/nvim/plugin/main.go
+++ b/nvim/plugin/main.go
@@ -45,6 +45,8 @@ import (
 //
 // If the --manifest=host command line flag is specified, then Main prints the
 // plugin manifest to stdout insead of running the application as a plugin.
+// If the --location=vimfile command line flag is specified, then plugin
+// manifest will be automatically written to .vim file.
 func Main(registerHandlers func(p *Plugin) error) {
 	pluginHost := flag.String("manifest", "", "Write plugin manifest for `host` to stdout")
 	vimFilePath := flag.String("location", "", "if this option is enable, manifest is automatically written `.vim file`")

--- a/nvim/plugin/main.go
+++ b/nvim/plugin/main.go
@@ -92,7 +92,7 @@ func overwriteManifest(path, host string, manifest []byte) error {
 }
 
 func replaceManifest(host string, input, manifest []byte) []byte {
-	p := regexp.MustCompile(`(?ms)^call remote#host#RegisterPlugin\('` + regexp.QuoteMeta(host) + `'.*?^\\ ]\)\n`)
+	p := regexp.MustCompile(`(?ms)^call remote#host#RegisterPlugin\('` + regexp.QuoteMeta(host) + `'.*?^\\ ]\)$`)
 	match := p.FindIndex(input)
 	var output []byte
 	if match == nil {

--- a/nvim/plugin/main.go
+++ b/nvim/plugin/main.go
@@ -61,7 +61,7 @@ func Main(registerHandlers func(p *Plugin) error) {
 		os.Stdout.Write(p.Manifest(*pluginHost))
 	}
 
-	if *vimFilePath != "" && *pluginHost != "" {
+	if *vimFilePath != "" {
 		log.SetFlags(0)
 		p := New(nil)
 		if err := registerHandlers(p); err != nil {
@@ -70,6 +70,9 @@ func Main(registerHandlers func(p *Plugin) error) {
 		if err := replaceManifest(*vimFilePath, p.Manifest(*pluginHost)); err != nil {
 			log.Fatal(err)
 		}
+	}
+
+	if *pluginHost != "" || *vimFilePath != "" {
 		return
 	}
 

--- a/nvim/plugin/main.go
+++ b/nvim/plugin/main.go
@@ -65,7 +65,7 @@ func Main(registerHandlers func(p *Plugin) error) {
 		if err := registerHandlers(p); err != nil {
 			log.Fatal(err)
 		}
-		if err := replaceManigest(*vimFilePath, p.Manifest(*pluginHost)); err != nil {
+		if err := replaceManifest(*vimFilePath, p.Manifest(*pluginHost)); err != nil {
 			log.Fatal(err)
 		}
 		return
@@ -88,7 +88,7 @@ func Main(registerHandlers func(p *Plugin) error) {
 	}
 }
 
-func replaceManigest(path string, newManifest []byte) error {
+func replaceManifest(path string, newManifest []byte) error {
 	lines := strings.Split(string(newManifest), "\n")
 	if len(lines) == 0 {
 		return errors.New("no manifest")

--- a/nvim/plugin/manifest_test.go
+++ b/nvim/plugin/manifest_test.go
@@ -27,7 +27,7 @@ endfunction
 		output := replaceManifest(host, []byte(vimFileContent), []byte(manifest))
 		expected := []byte(vimFileContent + manifest)
 		if !bytes.Equal(output, expected) {
-			t.Error("want %s, but get %s", string(expected), string(output))
+			t.Errorf("want %s, but get %s", string(expected), string(output))
 		}
 	})
 
@@ -67,7 +67,7 @@ call remote#host#RegisterPlugin('hello.nvim', '0', [
 \ ])
 `
 		if !bytes.Equal(output, []byte(expected)) {
-			t.Error("want %s, but get %s", expected, string(output))
+			t.Errorf("want %s, but get %s", expected, string(output))
 		}
 	})
 }

--- a/nvim/plugin/manifest_test.go
+++ b/nvim/plugin/manifest_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestOverwriteManifest(t *testing.T) {
+func TestReplaceManifest(t *testing.T) {
 
 	t.Run("not written manifest yet", func(t *testing.T) {
 		vimFileContent := `if exists('g:loaded_hello')
@@ -24,10 +24,10 @@ endfunction
 \ ])
 `
 		host := "hello.nvim"
-		output := overwriteManifest(host, []byte(vimFileContent), []byte(manifest))
+		output := replaceManifest(host, []byte(vimFileContent), []byte(manifest))
 		expected := []byte(vimFileContent + manifest)
 		if !bytes.Equal(output, expected) {
-			t.Error("failed")
+			t.Error("want %s, but get %s", string(expected), string(output))
 		}
 	})
 
@@ -51,7 +51,7 @@ call remote#host#RegisterPlugin('hello.nvim', '0', [
 \ ])
 `
 		host := "hello.nvim"
-		output := overwriteManifest(host, []byte(vimFileContent), []byte(manifest))
+		output := replaceManifest(host, []byte(vimFileContent), []byte(manifest))
 		expected := `if exists('g:loaded_hello')
   finish
 endif
@@ -67,7 +67,7 @@ call remote#host#RegisterPlugin('hello.nvim', '0', [
 \ ])
 `
 		if !bytes.Equal(output, []byte(expected)) {
-			t.Error("failed")
+			t.Error("want %s, but get %s", expected, string(output))
 		}
 	})
 }

--- a/nvim/plugin/manifest_test.go
+++ b/nvim/plugin/manifest_test.go
@@ -1,0 +1,73 @@
+package plugin
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestOverwriteManifest(t *testing.T) {
+
+	t.Run("not written manifest yet", func(t *testing.T) {
+		vimFileContent := `if exists('g:loaded_hello')
+  finish
+endif
+let g:loaded_hello = 1
+
+function! s:RequireHello(host) abort
+  return jobstart(['hello.nvim'], { 'rpc': v:true })
+endfunction
+`
+		manifest := `call remote#host#RegisterPlugin('hello.nvim', '0', [
+\ {'type': 'function', 'name': 'Ahello', 'sync': 1, 'opts': {}},
+\ {'type': 'function', 'name': 'Bhello', 'sync': 1, 'opts': {}},
+\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},
+\ ])
+`
+		host := "hello.nvim"
+		output := overwriteManifest(host, []byte(vimFileContent), []byte(manifest))
+		expected := []byte(vimFileContent + manifest)
+		if !bytes.Equal(output, expected) {
+			t.Error("failed")
+		}
+	})
+
+	t.Run("already written manifest", func(t *testing.T) {
+		vimFileContent := `if exists('g:loaded_hello')
+  finish
+endif
+let g:loaded_hello = 1
+
+function! s:RequireHello(host) abort
+  return jobstart(['hello.nvim'], { 'rpc': v:true })
+endfunction
+call remote#host#RegisterPlugin('hello.nvim', '0', [
+\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},
+\ ])
+`
+		manifest := `call remote#host#RegisterPlugin('hello.nvim', '0', [
+\ {'type': 'function', 'name': 'Ahello', 'sync': 1, 'opts': {}},
+\ {'type': 'function', 'name': 'Bhello', 'sync': 1, 'opts': {}},
+\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},
+\ ])
+`
+		host := "hello.nvim"
+		output := overwriteManifest(host, []byte(vimFileContent), []byte(manifest))
+		expected := `if exists('g:loaded_hello')
+  finish
+endif
+let g:loaded_hello = 1
+
+function! s:RequireHello(host) abort
+  return jobstart(['hello.nvim'], { 'rpc': v:true })
+endfunction
+call remote#host#RegisterPlugin('hello.nvim', '0', [
+\ {'type': 'function', 'name': 'Ahello', 'sync': 1, 'opts': {}},
+\ {'type': 'function', 'name': 'Bhello', 'sync': 1, 'opts': {}},
+\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},
+\ ])
+`
+		if !bytes.Equal(output, []byte(expected)) {
+			t.Error("failed")
+		}
+	})
+}

--- a/nvim/plugin/manifest_test.go
+++ b/nvim/plugin/manifest_test.go
@@ -8,21 +8,33 @@ import (
 func TestReplaceManifest(t *testing.T) {
 
 	t.Run("not written manifest yet", func(t *testing.T) {
-		vimFileContent := `if exists('g:loaded_hello')
-  finish
-endif
-let g:loaded_hello = 1
+		vimFileContentLines := []string{
+			`if exists('g:loaded_hello')`,
+			`  finish`,
+			`endif`,
+			`let g:loaded_hello = 1`,
+			``,
+			`function! s:RequireHello(host) abort`,
+			`  return jobstart(['hello.nvim'], { 'rpc': v:true })`,
+			`endfunction`,
+		}
+		var vimFileContent string
+		for _, l := range vimFileContentLines {
+			vimFileContent = vimFileContent + l + "\n"
+		}
 
-function! s:RequireHello(host) abort
-  return jobstart(['hello.nvim'], { 'rpc': v:true })
-endfunction
-`
-		manifest := `call remote#host#RegisterPlugin('hello.nvim', '0', [
-\ {'type': 'function', 'name': 'Ahello', 'sync': 1, 'opts': {}},
-\ {'type': 'function', 'name': 'Bhello', 'sync': 1, 'opts': {}},
-\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},
-\ ])
-`
+		manifestLines := []string{
+			`call remote#host#RegisterPlugin('hello.nvim', '0', [`,
+			`\ {'type': 'function', 'name': 'Ahello', 'sync': 1, 'opts': {}},`,
+			`\ {'type': 'function', 'name': 'Bhello', 'sync': 1, 'opts': {}},`,
+			`\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},`,
+			`\ ])`,
+		}
+		var manifest string
+		for _, l := range manifestLines {
+			manifest = manifest + l + "\n"
+		}
+
 		host := "hello.nvim"
 		output := replaceManifest(host, []byte(vimFileContent), []byte(manifest))
 		expected := []byte(vimFileContent + manifest)
@@ -32,40 +44,59 @@ endfunction
 	})
 
 	t.Run("already written manifest", func(t *testing.T) {
-		vimFileContent := `if exists('g:loaded_hello')
-  finish
-endif
-let g:loaded_hello = 1
+		vimFileContentLines := []string{
+			`if exists('g:loaded_hello')`,
+			`  finish`,
+			`endif`,
+			`let g:loaded_hello = 1`,
+			``,
+			`function! s:RequireHello(host) abort`,
+			`  return jobstart(['hello.nvim'], { 'rpc': v:true })`,
+			`endfunction`,
+			`call remote#host#RegisterPlugin('hello.nvim', '0', [`,
+			`\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},`,
+			`\ ])`,
+		}
+		var vimFileContent string
+		for _, l := range vimFileContentLines {
+			vimFileContent = vimFileContent + l + "\n"
+		}
 
-function! s:RequireHello(host) abort
-  return jobstart(['hello.nvim'], { 'rpc': v:true })
-endfunction
-call remote#host#RegisterPlugin('hello.nvim', '0', [
-\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},
-\ ])
-`
-		manifest := `call remote#host#RegisterPlugin('hello.nvim', '0', [
-\ {'type': 'function', 'name': 'Ahello', 'sync': 1, 'opts': {}},
-\ {'type': 'function', 'name': 'Bhello', 'sync': 1, 'opts': {}},
-\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},
-\ ])
-`
+		manifestLines := []string{
+			`call remote#host#RegisterPlugin('hello.nvim', '0', [`,
+			`\ {'type': 'function', 'name': 'Ahello', 'sync': 1, 'opts': {}},`,
+			`\ {'type': 'function', 'name': 'Bhello', 'sync': 1, 'opts': {}},`,
+			`\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},`,
+			`\ ])`,
+		}
+		var manifest string
+		for _, l := range manifestLines {
+			manifest = manifest + l + "\n"
+		}
+
 		host := "hello.nvim"
 		output := replaceManifest(host, []byte(vimFileContent), []byte(manifest))
-		expected := `if exists('g:loaded_hello')
-  finish
-endif
-let g:loaded_hello = 1
 
-function! s:RequireHello(host) abort
-  return jobstart(['hello.nvim'], { 'rpc': v:true })
-endfunction
-call remote#host#RegisterPlugin('hello.nvim', '0', [
-\ {'type': 'function', 'name': 'Ahello', 'sync': 1, 'opts': {}},
-\ {'type': 'function', 'name': 'Bhello', 'sync': 1, 'opts': {}},
-\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},
-\ ])
-`
+		expectedLines := []string{
+			`if exists('g:loaded_hello')`,
+			`  finish`,
+			`endif`,
+			`let g:loaded_hello = 1`,
+			``,
+			`function! s:RequireHello(host) abort`,
+			`  return jobstart(['hello.nvim'], { 'rpc': v:true })`,
+			`endfunction`,
+			`call remote#host#RegisterPlugin('hello.nvim', '0', [`,
+			`\ {'type': 'function', 'name': 'Ahello', 'sync': 1, 'opts': {}},`,
+			`\ {'type': 'function', 'name': 'Bhello', 'sync': 1, 'opts': {}},`,
+			`\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},`,
+			`\ ])`,
+		}
+		var expected string
+		for _, l := range expectedLines {
+			expected = expected + l + "\n"
+		}
+
 		if !bytes.Equal(output, []byte(expected)) {
 			t.Errorf("want %s, but get %s", expected, string(output))
 		}

--- a/nvim/plugin/manifest_test.go
+++ b/nvim/plugin/manifest_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 )
 
@@ -18,10 +19,7 @@ func TestReplaceManifest(t *testing.T) {
 			`  return jobstart(['hello.nvim'], { 'rpc': v:true })`,
 			`endfunction`,
 		}
-		var vimFileContent string
-		for _, l := range vimFileContentLines {
-			vimFileContent = vimFileContent + l + "\n"
-		}
+		vimFileContent := strings.Join(vimFileContentLines, "\n")
 
 		manifestLines := []string{
 			`call remote#host#RegisterPlugin('hello.nvim', '0', [`,
@@ -30,10 +28,7 @@ func TestReplaceManifest(t *testing.T) {
 			`\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},`,
 			`\ ])`,
 		}
-		var manifest string
-		for _, l := range manifestLines {
-			manifest = manifest + l + "\n"
-		}
+		manifest := strings.Join(manifestLines, "\n")
 
 		host := "hello.nvim"
 		output := replaceManifest(host, []byte(vimFileContent), []byte(manifest))
@@ -57,10 +52,7 @@ func TestReplaceManifest(t *testing.T) {
 			`\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},`,
 			`\ ])`,
 		}
-		var vimFileContent string
-		for _, l := range vimFileContentLines {
-			vimFileContent = vimFileContent + l + "\n"
-		}
+		vimFileContent := strings.Join(vimFileContentLines, "\n")
 
 		manifestLines := []string{
 			`call remote#host#RegisterPlugin('hello.nvim', '0', [`,
@@ -69,10 +61,7 @@ func TestReplaceManifest(t *testing.T) {
 			`\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},`,
 			`\ ])`,
 		}
-		var manifest string
-		for _, l := range manifestLines {
-			manifest = manifest + l + "\n"
-		}
+		manifest := strings.Join(manifestLines, "\n")
 
 		host := "hello.nvim"
 		output := replaceManifest(host, []byte(vimFileContent), []byte(manifest))
@@ -92,10 +81,7 @@ func TestReplaceManifest(t *testing.T) {
 			`\ {'type': 'function', 'name': 'Hello', 'sync': 1, 'opts': {}},`,
 			`\ ])`,
 		}
-		var expected string
-		for _, l := range expectedLines {
-			expected = expected + l + "\n"
-		}
+		expected := strings.Join(expectedLines, "\n")
 
 		if !bytes.Equal(output, []byte(expected)) {
 			t.Errorf("want %s, but get %s", expected, string(output))


### PR DESCRIPTION
Add feature #1. (but there is only a part of this issue)
use `--location=vimfilepath` (and simultaneously `--manifest=hostName`), only manifests with the same host name in `.vim file` are overwritten.
If an existing manifest is not defined, add it to the end of the `.vim file`.