### PR TITLE
msgpack: add support for empty field tag

### DIFF
--- a/msgpack/decode_test.go
+++ b/msgpack/decode_test.go
@@ -23,12 +23,21 @@ import (
 
 type testDecStruct struct {
 	I  interface{}
+	B  bool
 	S  string
 	N  int
 	U  uint
 	F  float64
 	Sl []string
 	M  map[string]interface{}
+}
+
+type testDecEmptyStruct struct {
+	B   bool   `empty:"true"`
+	S   string `empty:"blank"`
+	N   int    `empty:"1234"`
+	N8  int8   `empty:"45"`
+	N32 int32  `empty:"6789"`
 }
 
 type testDecArrayStruct struct {
@@ -111,6 +120,10 @@ var decodeTests = []struct {
 	{func() interface{} { return new(interface{}) }, []interface{}{extension{0, "hello"}}, extensionValue{0, []byte("hello")}},
 	{func() interface{} { return new(interface{}) }, []interface{}{extension{1, "hello"}}, testExtension1{[]byte("hello")}},
 	{func() interface{} { return new(testExtension1) }, []interface{}{extension{1, "hello"}}, testExtension1{[]byte("hello")}},
+
+	// Empty
+	{func() interface{} { return &testDecEmptyStruct{} }, []interface{}{mapLen(0)}, testDecEmptyStruct{B: true, S: "blank", N: 1234, N8: 45, N32: 6789}},
+	{func() interface{} { return &testDecEmptyStruct{} }, []interface{}{mapLen(1), "S", "not blank"}, testDecEmptyStruct{B: true, S: "not blank", N: 1234, N8: 45, N32: 6789}},
 
 	// TODO: test errors like the following:
 	// {func() interface{} { return &testDecStruct{I: 1234} }, []interface{}{mapLen(1), "I", int64(5678)}, testDecStruct{I: 1234}},

--- a/msgpack/encode_test.go
+++ b/msgpack/encode_test.go
@@ -103,12 +103,15 @@ var encodeTests = []struct {
 	{struct {
 		B  bool `msgpack:"b,omitempty"`
 		Bo bool `msgpack:"bo,omitempty"`
+		Be bool `msgpack:"be,omitempty" empty:"true"`
 
 		S  string `msgpack:"s,omitempty"`
 		So string `msgpack:"so,omitempty"`
+		Se string `msgpack:"se,omitempty" empty:"blank"`
 
 		I  int `msgpack:"i,omitempty"`
 		Io int `msgpack:"io,omitempty"`
+		Ie int `msgpack:"ie,omitempty" empty:"-1"`
 
 		U  uint `msgpack:"u,omitempty"`
 		Uo uint `msgpack:"uo,omitempty"`
@@ -129,8 +132,11 @@ var encodeTests = []struct {
 		Po *int `msgpack:"po,omitempty"`
 	}{
 		B:  false,
+		Be: true,
 		S:  "1",
+		Se: "blank",
 		I:  2,
+		Ie: -1,
 		U:  3,
 		F:  4.0,
 		D:  5.0,

--- a/msgpack/unpack.go
+++ b/msgpack/unpack.go
@@ -25,6 +25,7 @@ import (
 // Type represents the type of value in the MsgPack stream.
 type Type int
 
+// MsgPack types.
 const (
 	Invalid Type = iota
 	Nil


### PR DESCRIPTION
The value fo the "empty" field tag specifies a default value to use for
the fiend when decoding and the empty value for "omitempty" option when
encoding.