### PR TITLE
Add NewChildProces and Dial functions

### DIFF
--- a/nvim/doc.go
+++ b/nvim/doc.go
@@ -18,9 +18,8 @@
 // Nvim plugins.
 //
 // The Nvim type implements the client. To connect to a running instance of
-// Nvim, create a *Nvim value using the New or NewEmbedded functions and call
-// the Serve() method to process RPC messages. Call the Close() method to
-// release the resources used by the client.
+// Nvim, create a *Nvim value using the Dial or NewChildProcess functions.
+// Call the Close() method to release the resources used by the client.
 //
 // Use the Batch type to execute a sequence of Nvim API calls atomically. The
 // Nvim NewBatch method creates new *Batch values.

--- a/nvim/example_test.go
+++ b/nvim/example_test.go
@@ -1,0 +1,49 @@
+package nvim_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/neovim/go-client/nvim"
+)
+
+// This program lists the names of the Nvim buffers when run from an Nvim
+// terminal. It dials to Nvim using the $NVIM_LISTEN_ADDRESS and fetches all of
+// the buffer names in one call using a batch.
+func Example() {
+	// Get address from environment variable set by Nvim.
+	addr := os.Getenv("NVIM_LISTEN_ADDRESS")
+	if addr == "" {
+		log.Fatal("NVIM_LISTEN_ADDRESS not set")
+	}
+
+	// Dial with default options.
+	v, err := nvim.Dial(addr)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Cleanup on return.
+	defer v.Close()
+
+	bufs, err := v.Buffers()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Get the names using a single atomic call to Nvim.
+	names := make([]string, len(bufs))
+	b := v.NewBatch()
+	for i, buf := range bufs {
+		b.BufferName(buf, &names[i])
+	}
+	if err := b.Execute(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Print the names.
+	for _, name := range names {
+		fmt.Println(name)
+	}
+}

--- a/nvim/helpers_test.go
+++ b/nvim/helpers_test.go
@@ -30,7 +30,7 @@ var readerData = []string{
 }
 
 func TestBufferReader(t *testing.T) {
-	v, cleanup := newEmbeddedNvim(t)
+	v, cleanup := newChildProcess(t)
 	defer cleanup()
 	b, err := v.CurrentBuffer()
 	if err != nil {


### PR DESCRIPTION
Add high-level functions for creating an Nvim client. These functions
run Serve() in a goroutine by default and cleanup the goroutine in
Close().

Deprecate NewEmbedded. The NewChildProcess function is easier to use and
more flexible.