### PR TITLE
Fixing issue with BufferLines Unpack when there are a lot of long lines

### DIFF
--- a/msgpack/unpack.go
+++ b/msgpack/unpack.go
@@ -209,7 +209,7 @@ func (d *Decoder) Unpack() error {
 	} else {
 		d.peek = false
 		d.p = make([]byte, nn)
-		_, err := d.r.Read(d.p)
+		_, err := io.ReadFull(d.r, d.p)
 		if err != nil {
 			return d.fatal(err)
 		}


### PR DESCRIPTION
I was playing around with reading lines from a buffer and ran into a parsing error. Specifically I was getting this error ` msgpack: cannot convert Int to []uint8` and only part of one of the lines was being read.

I am also going to include the test file I used so you can run any tests you'd like.
