### PR TITLE
nvim: add '--headless' flag to newChildProcess for non-exit testcase

### DIFF
--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -26,7 +26,7 @@ import (
 
 func newChildProcess(t *testing.T) (*Nvim, func()) {
 	v, err := NewChildProcess(
-		ChildProcessArgs("-u", "NONE", "-n", "--embed"),
+		ChildProcessArgs("-u", "NONE", "-n", "--embed", "--headless"),
 		ChildProcessEnv([]string{}),
 		ChildProcessLogf(t.Logf))
 	if err != nil {


### PR DESCRIPTION
Add `--headless` flag to `newChildProcess` for non-exit test case.

As mentioned https://github.com/neovim/go-client/pull/36#issuecomment-469390735, The `nvim` packages `TestAPI` and `TestDial` testcases are doesn't finish (stopped) at least my local env and TravisCI.

I don't know whether this change is correct, but all testcases are not stopped and passes.

---

@justinmk
This pull request seems to be related to the core implementation of nvim, so added you as a reviewer.
Is this correct change?