### PR TITLE
Allow to perform naked RPC requests

### DIFF
--- a/nvim/apiimp.go
+++ b/nvim/apiimp.go
@@ -1160,3 +1160,16 @@ func (v *Nvim) IsWindowValid(window Window) (bool, error) {
 func (b *Batch) IsWindowValid(window Window, result *bool) {
 	b.call("nvim_win_is_valid", result, window)
 }
+
+// Invoke makes a RPC request.
+func (v *Nvim) Invoke(procedure string, result interface{}, args ...interface{}) error {
+	if args == nil {
+		args = []interface{}{}
+	}
+	return v.ep.Call(procedure, result, args...)
+}
+
+// Invoke makes a RPC request atomically as a part of batch request.
+func (b *Batch) Invoke(procedure string, result interface{}, args ...interface{}) {
+	b.call(procedure, result, args...)
+}

--- a/nvim/apiimp.go
+++ b/nvim/apiimp.go
@@ -1160,16 +1160,3 @@ func (v *Nvim) IsWindowValid(window Window) (bool, error) {
 func (b *Batch) IsWindowValid(window Window, result *bool) {
 	b.call("nvim_win_is_valid", result, window)
 }
-
-// Invoke makes a RPC request.
-func (v *Nvim) Invoke(procedure string, result interface{}, args ...interface{}) error {
-	if args == nil {
-		args = []interface{}{}
-	}
-	return v.ep.Call(procedure, result, args...)
-}
-
-// Invoke makes a RPC request atomically as a part of batch request.
-func (b *Batch) Invoke(procedure string, result interface{}, args ...interface{}) {
-	b.call(procedure, result, args...)
-}

--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -567,6 +567,14 @@ func (v *Nvim) Call(fname string, result interface{}, args ...interface{}) error
 	return v.call("nvim_call_function", result, fname, args)
 }
 
+// Invoke makes a RPC request.
+func (v *Nvim) Invoke(procedure string, result interface{}, args ...interface{}) error {
+	if args == nil {
+		args = []interface{}{}
+	}
+	return v.ep.Call(procedure, result, args...)
+}
+
 // Call calls a vimscript function.
 func (b *Batch) Call(fname string, result interface{}, args ...interface{}) {
 	if args == nil {

--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -559,12 +559,22 @@ func (el ErrorList) Error() string {
 	return el[0].Error()
 }
 
+// Invoke makes a RPC request.
+func (v *Nvim) Invoke(procedure string, result interface{}, args ...interface{}) error {
+	return v.call(procedure, result, args...)
+}
+
 // Call calls a vimscript function.
 func (v *Nvim) Call(fname string, result interface{}, args ...interface{}) error {
 	if args == nil {
 		args = []interface{}{}
 	}
 	return v.call("nvim_call_function", result, fname, args)
+}
+
+// Invoke makes a RPC request atomically as a part of batch request.
+func (b *Batch) Invoke(procedure string, result interface{}, args ...interface{}) {
+	b.call(procedure, result, args...)
 }
 
 // Call calls a vimscript function.

--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -567,14 +567,6 @@ func (v *Nvim) Call(fname string, result interface{}, args ...interface{}) error
 	return v.call("nvim_call_function", result, fname, args)
 }
 
-// Invoke makes a RPC request.
-func (v *Nvim) Invoke(procedure string, result interface{}, args ...interface{}) error {
-	if args == nil {
-		args = []interface{}{}
-	}
-	return v.ep.Call(procedure, result, args...)
-}
-
 // Call calls a vimscript function.
 func (b *Batch) Call(fname string, result interface{}, args ...interface{}) {
 	if args == nil {

--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -559,8 +559,8 @@ func (el ErrorList) Error() string {
 	return el[0].Error()
 }
 
-// Invoke makes a RPC request.
-func (v *Nvim) Invoke(procedure string, result interface{}, args ...interface{}) error {
+// Request makes a RPC request.
+func (v *Nvim) Request(procedure string, result interface{}, args ...interface{}) error {
 	return v.call(procedure, result, args...)
 }
 
@@ -572,8 +572,8 @@ func (v *Nvim) Call(fname string, result interface{}, args ...interface{}) error
 	return v.call("nvim_call_function", result, fname, args)
 }
 
-// Invoke makes a RPC request atomically as a part of batch request.
-func (b *Batch) Invoke(procedure string, result interface{}, args ...interface{}) {
+// Request makes a RPC request atomically as a part of batch request.
+func (b *Batch) Request(procedure string, result interface{}, args ...interface{}) {
 	b.call(procedure, result, args...)
 }
 


### PR DESCRIPTION
In order to avoid situation when NeoVim API is updated but there is no support in Golang client I propose the method `Nvim.Invoke()`. This allow everybody to use the newest API level as soon as possible. As example pull request #36 is under review about half a year.