### PR TITLE
Fix `SetBufferVirtualText` chunks arg type

### DIFF
--- a/nvim/apidef.go
+++ b/nvim/apidef.go
@@ -203,7 +203,7 @@ func ClearBufferHighlight(buffer Buffer, srcID int, startLine int, endLine int) 
 	name(nvim_buf_clear_highlight)
 }
 
-// Set the virtual text (annotation) for a buffer line.
+// SetBufferVirtualText sets the virtual text (annotation) for a buffer line.
 //
 // By default (and currently the only option) the text will be placed after
 // the buffer text. Virtual text will never cause reflow, rather virtual
@@ -222,7 +222,7 @@ func ClearBufferHighlight(buffer Buffer, srcID int, startLine int, endLine int) 
 // The `opts` is optional parameters. Currently not used.
 //
 // The returns the nsID that was used.
-func SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []interface{}, opts map[string]interface{}) int {
+func SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []VirtualTextChunk, opts map[string]interface{}) int {
 	name(nvim_buf_set_virtual_text)
 }
 

--- a/nvim/apiimp.go
+++ b/nvim/apiimp.go
@@ -495,7 +495,7 @@ func (b *Batch) ClearBufferHighlight(buffer Buffer, srcID int, startLine int, en
 	b.call("nvim_buf_clear_highlight", nil, buffer, srcID, startLine, endLine)
 }
 
-// Set the virtual text (annotation) for a buffer line.
+// SetBufferVirtualText sets the virtual text (annotation) for a buffer line.
 //
 // By default (and currently the only option) the text will be placed after
 // the buffer text. Virtual text will never cause reflow, rather virtual
@@ -514,13 +514,13 @@ func (b *Batch) ClearBufferHighlight(buffer Buffer, srcID int, startLine int, en
 // The `opts` is optional parameters. Currently not used.
 //
 // The returns the nsID that was used.
-func (v *Nvim) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []interface{}, opts map[string]interface{}) (int, error) {
+func (v *Nvim) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []VirtualTextChunk, opts map[string]interface{}) (int, error) {
 	var result int
 	err := v.call("nvim_buf_set_virtual_text", &result, buffer, nsID, line, chunks, opts)
 	return result, err
 }
 
-// Set the virtual text (annotation) for a buffer line.
+// SetBufferVirtualText sets the virtual text (annotation) for a buffer line.
 //
 // By default (and currently the only option) the text will be placed after
 // the buffer text. Virtual text will never cause reflow, rather virtual
@@ -539,7 +539,7 @@ func (v *Nvim) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []
 // The `opts` is optional parameters. Currently not used.
 //
 // The returns the nsID that was used.
-func (b *Batch) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []interface{}, opts map[string]interface{}, result *int) {
+func (b *Batch) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []VirtualTextChunk, opts map[string]interface{}, result *int) {
 	b.call("nvim_buf_set_virtual_text", result, buffer, nsID, line, chunks, opts)
 }
 

--- a/nvim/apitool.go
+++ b/nvim/apitool.go
@@ -308,13 +308,14 @@ var nvimTypes = map[string]string{
 	"[][]byte":  "ArrayOf(String)",
 	"[]string":  "ArrayOf(String)",
 
-	"Mode":       "Dictionary",
-	"*HLAttrs":   "Dictionary",
-	"*Channel":   "Dictionary",
-	"[]*Channel": "Array",
-	"[]*Mapping": "ArrayOf(Dictionary)",
-	"[]*Process": "Array",
-	"[]*UI":      "Array",
+	"Mode":               "Dictionary",
+	"*HLAttrs":           "Dictionary",
+	"*Channel":           "Dictionary",
+	"[]*Channel":         "Array",
+	"[]*Mapping":         "ArrayOf(Dictionary)",
+	"[]*Process":         "Array",
+	"[]*UI":              "Array",
+	"[]VirtualTextChunk": "Array",
 }
 
 func convertToNvimTypes(f *Function) *Function {

--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -482,6 +482,39 @@ func TestAPI(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("virtual_text", func(t *testing.T) {
+		clearBuffer(t, v, 0) // clear curret buffer text
+
+		nsID, err := v.CreateNamespace("test_virtual_text")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		lines := []byte("ping")
+		if err := v.SetBufferLines(0, 0, -1, true, bytes.Fields(lines)); err != nil {
+			t.Fatal(err)
+		}
+
+		chunks := []VirtualTextChunk{
+			{
+				Text:    "pong",
+				HLGroup: "String",
+			},
+		}
+		nsID2, err := v.SetBufferVirtualText(0, nsID, 0, chunks, make(map[string]interface{}))
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got := nsID2; got != nsID {
+			t.Fatalf("namespaceID: got %d, want %d", got, nsID)
+		}
+
+		if err := v.ClearBufferNamespace(0, nsID, 0, -1); err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func TestDial(t *testing.T) {

--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -383,15 +383,7 @@ func TestAPI(t *testing.T) {
 	})
 
 	t.Run("buf_attach", func(t *testing.T) {
-		buffer, err := v.CurrentBuffer()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// clear curret buffer text
-		if err := v.SetBufferLines(buffer, 0, -1, true, bytes.Fields(nil)); err != nil {
-			t.Fatal(err)
-		}
+		clearBuffer(t, v, 0) // clear curret buffer text
 
 		type ChangedtickEvent struct {
 			Buffer     Buffer
@@ -428,7 +420,7 @@ func TestAPI(t *testing.T) {
 			bufLinesChan <- ev
 		})
 
-		ok, err := v.AttachBuffer(buffer, false, make(map[string]interface{}))
+		ok, err := v.AttachBuffer(0, false, make(map[string]interface{})) // first 0 arg refers to the current buffer
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -480,7 +472,7 @@ func TestAPI(t *testing.T) {
 		}()
 
 		test := []byte("test")
-		if err := v.SetBufferLines(buffer, 0, -1, true, bytes.Fields(test)); err != nil {
+		if err := v.SetBufferLines(0, 0, -1, true, bytes.Fields(test)); err != nil { // first 0 arg refers to the current buffer
 			t.Fatal(err)
 		}
 
@@ -561,5 +553,12 @@ func TestEmbedded(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timeout waiting for serve to exit")
+	}
+}
+
+// clearBuffer clear the buffer text.
+func clearBuffer(t *testing.T, v *Nvim, buffer Buffer) {
+	if err := v.SetBufferLines(buffer, 0, -1, true, bytes.Fields(nil)); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/nvim/types.go
+++ b/nvim/types.go
@@ -229,3 +229,9 @@ type Command struct {
 	CompleteArg string `msgpack:"complete_arg,omitempty"`
 	Definition  string `msgpack:"definition"`
 }
+
+// VirtualTextChunk represents a virtual text chunk.
+type VirtualTextChunk struct {
+	Text    string `msgpack:",array"`
+	HLGroup string `msgpack:",array"`
+}


### PR DESCRIPTION
Fix `SetBufferVirtualText` chunks arg type and fix godoc comment.

In the `chunks` arg on `SetBufferVirtualText`, `[]interface{}` type not developer friendly. Add `VirtualTextChunk` struct type and change `chunks` type to `[]VirtualTextChunk`.

The example usage exists in `nvim_test.go`.