### PR TITLE
Remove older Go version support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ before_install:
 
 matrix:
   include:
-  - go: 1.7.x
-  - go: 1.8.x
-  - go: 1.9.x
-  - go: 1.10.x
   - go: 1.11.x
   - go: 1.12.x
     env: GO111MODULE=on

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ matrix:
     env: GO111MODULE=on
   - go: 1.12.x
     env: GO111MODULE=on
+  - go: 1.13.x
+    env: GO111MODULE=on
   - go: tip
     env: GO111MODULE=on
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
 matrix:
   include:
   - go: 1.11.x
+    env: GO111MODULE=on
   - go: 1.12.x
     env: GO111MODULE=on
   - go: tip

--- a/go.mod
+++ b/go.mod
@@ -1,1 +1,3 @@
 module github.com/neovim/go-client
+
+go 1.11


### PR DESCRIPTION
Remove `1.7.x` ~ `1.10.x` Go older version support from Travis CI. And adding `1.13.x` version.

IMO, Mostly, many Go packages support the latest version and two older versions.

Especially, `1.7.x` and `1.8.x` are too old. Now I'm trying to optimize each implementation by writing the benchmark code, but there is no `testing.TB.Helper()` functions or etc. See
- https://travis-ci.org/neovim/go-client/jobs/606392860#L251
- https://travis-ci.org/neovim/go-client/jobs/606392861#L258

In the Go language community, Currently, with the release of the Go 1.13 version, the module has become almost standard. I think no needs to supporting 1.10 or older versions.

**Note that** the `go.mod` file is valid after `1.11.x`. This change does not mean that it can't compile on 1.10 or older versions. However, I may add any changes that will can't compile on those versions in the future.