### PR TITLE
Add `WindowConfig` for `OpenWindow`

### DIFF
--- a/nvim/apidef.go
+++ b/nvim/apidef.go
@@ -530,7 +530,7 @@ func CreateBuffer(listed, scratch bool) Buffer {
 // this should not be used to specify arbitrary WM screen positions.
 //
 // The returns the window handle or 0 when error.
-func OpenWindow(buffer Buffer, enter bool, config *OpenWindowConfig) Window {
+func OpenWindow(buffer Buffer, enter bool, config *WindowConfig) Window {
 	name(nvim_open_win)
 }
 

--- a/nvim/apidef.go
+++ b/nvim/apidef.go
@@ -505,30 +505,32 @@ func CreateBuffer(listed, scratch bool) Buffer {
 	name(nvim_create_buf)
 }
 
-// OpenWindow open a new window.
+// OpenWindow opens a new window.
 //
 // Currently this is used to open floating and external windows.
 // Floats are windows that are drawn above the split layout, at some anchor
-// position in some other window. Floats can be draw internally or by external
+// position in some other window. Floats can be drawn internally or by external
 // GUI with the |ui-multigrid| extension. External windows are only supported
 // with multigrid GUIs, and are displayed as separate top-level windows.
 //
-// Exactly one of `external` and `relative` must be specified.
+// For a general overview of floats, see |api-floatwin|.
 //
-// With editor positioning row=0, col=0 refers to the top-left corner of the
-// screen-grid and row=Lines-1, Columns-1 refers to the bottom-right corner.
-// Floating point values are allowed, but the builtin implementation (used by
-// TUI and GUIs without multigrid support) will always round down to nearest
-// integer.
+// Exactly one of External and Relative must be specified. The Width and
+// Height of the new window must be specified.
+//
+// With relative=editor (row=0,col=0) refers to the top-left corner of the
+// screen-grid and (row=Lines-1,col=Columns-1) refers to the bottom-right
+// corner. Fractional values are allowed, but the builtin implementation
+// (used by non-multigrid UIs) will always round down to nearest integer.
 //
 // Out-of-bounds values, and configurations that make the float not fit inside
-// the main editor, are allowed. The builtin implementation will truncate
-// values so floats are completely within the main screen grid. External GUIs
+// the main editor, are allowed. The builtin implementation truncates values
+// so floats are fully within the main screen grid. External GUIs
 // could let floats hover outside of the main window like a tooltip, but
 // this should not be used to specify arbitrary WM screen positions.
 //
 // The returns the window handle or 0 when error.
-func OpenWindow(buffer Buffer, enter bool, config map[string]interface{}) Window {
+func OpenWindow(buffer Buffer, enter bool, config *OpenWindowConfig) Window {
 	name(nvim_open_win)
 }
 
@@ -613,7 +615,7 @@ func KeyMap(mode string) []*Mapping {
 //  rhs
 // Right-hand-side {rhs} of the mapping.
 //
-//   opts
+//  opts
 // Optional parameters map. Accepts all :map-arguments as keys excluding <buffer> but including noremap.
 // Values are Booleans. Unknown key is an error.
 func SetKeyMap(mode, lhs, rhs string, opts map[string]bool) {

--- a/nvim/apiimp.go
+++ b/nvim/apiimp.go
@@ -1135,59 +1135,63 @@ func (b *Batch) CreateBuffer(listed bool, scratch bool, result *Buffer) {
 	b.call("nvim_create_buf", result, listed, scratch)
 }
 
-// OpenWindow open a new window.
+// OpenWindow opens a new window.
 //
 // Currently this is used to open floating and external windows.
 // Floats are windows that are drawn above the split layout, at some anchor
-// position in some other window. Floats can be draw internally or by external
+// position in some other window. Floats can be drawn internally or by external
 // GUI with the |ui-multigrid| extension. External windows are only supported
 // with multigrid GUIs, and are displayed as separate top-level windows.
 //
-// Exactly one of `external` and `relative` must be specified.
+// For a general overview of floats, see |api-floatwin|.
 //
-// With editor positioning row=0, col=0 refers to the top-left corner of the
-// screen-grid and row=Lines-1, Columns-1 refers to the bottom-right corner.
-// Floating point values are allowed, but the builtin implementation (used by
-// TUI and GUIs without multigrid support) will always round down to nearest
-// integer.
+// Exactly one of External and Relative must be specified. The Width and
+// Height of the new window must be specified.
+//
+// With relative=editor (row=0,col=0) refers to the top-left corner of the
+// screen-grid and (row=Lines-1,col=Columns-1) refers to the bottom-right
+// corner. Fractional values are allowed, but the builtin implementation
+// (used by non-multigrid UIs) will always round down to nearest integer.
 //
 // Out-of-bounds values, and configurations that make the float not fit inside
-// the main editor, are allowed. The builtin implementation will truncate
-// values so floats are completely within the main screen grid. External GUIs
+// the main editor, are allowed. The builtin implementation truncates values
+// so floats are fully within the main screen grid. External GUIs
 // could let floats hover outside of the main window like a tooltip, but
 // this should not be used to specify arbitrary WM screen positions.
 //
 // The returns the window handle or 0 when error.
-func (v *Nvim) OpenWindow(buffer Buffer, enter bool, config map[string]interface{}) (Window, error) {
+func (v *Nvim) OpenWindow(buffer Buffer, enter bool, config *OpenWindowConfig) (Window, error) {
 	var result Window
 	err := v.call("nvim_open_win", &result, buffer, enter, config)
 	return result, err
 }
 
-// OpenWindow open a new window.
+// OpenWindow opens a new window.
 //
 // Currently this is used to open floating and external windows.
 // Floats are windows that are drawn above the split layout, at some anchor
-// position in some other window. Floats can be draw internally or by external
+// position in some other window. Floats can be drawn internally or by external
 // GUI with the |ui-multigrid| extension. External windows are only supported
 // with multigrid GUIs, and are displayed as separate top-level windows.
 //
-// Exactly one of `external` and `relative` must be specified.
+// For a general overview of floats, see |api-floatwin|.
 //
-// With editor positioning row=0, col=0 refers to the top-left corner of the
-// screen-grid and row=Lines-1, Columns-1 refers to the bottom-right corner.
-// Floating point values are allowed, but the builtin implementation (used by
-// TUI and GUIs without multigrid support) will always round down to nearest
-// integer.
+// Exactly one of External and Relative must be specified. The Width and
+// Height of the new window must be specified.
+//
+// With relative=editor (row=0,col=0) refers to the top-left corner of the
+// screen-grid and (row=Lines-1,col=Columns-1) refers to the bottom-right
+// corner. Fractional values are allowed, but the builtin implementation
+// (used by non-multigrid UIs) will always round down to nearest integer.
 //
 // Out-of-bounds values, and configurations that make the float not fit inside
-// the main editor, are allowed. The builtin implementation will truncate
-// values so floats are completely within the main screen grid. External GUIs
+// the main editor, are allowed. The builtin implementation truncates values
+// so floats are fully within the main screen grid. External GUIs
 // could let floats hover outside of the main window like a tooltip, but
 // this should not be used to specify arbitrary WM screen positions.
 //
 // The returns the window handle or 0 when error.
-func (b *Batch) OpenWindow(buffer Buffer, enter bool, config map[string]interface{}, result *Window) {
+func (b *Batch) OpenWindow(buffer Buffer, enter bool, config *OpenWindowConfig, result *Window) {
 	b.call("nvim_open_win", result, buffer, enter, config)
 }
 
@@ -1350,7 +1354,7 @@ func (b *Batch) KeyMap(mode string, result *[]*Mapping) {
 //  rhs
 // Right-hand-side {rhs} of the mapping.
 //
-//   opts
+//  opts
 // Optional parameters map. Accepts all :map-arguments as keys excluding <buffer> but including noremap.
 // Values are Booleans. Unknown key is an error.
 func (v *Nvim) SetKeyMap(mode string, lhs string, rhs string, opts map[string]bool) error {
@@ -1374,7 +1378,7 @@ func (v *Nvim) SetKeyMap(mode string, lhs string, rhs string, opts map[string]bo
 //  rhs
 // Right-hand-side {rhs} of the mapping.
 //
-//   opts
+//  opts
 // Optional parameters map. Accepts all :map-arguments as keys excluding <buffer> but including noremap.
 // Values are Booleans. Unknown key is an error.
 func (b *Batch) SetKeyMap(mode string, lhs string, rhs string, opts map[string]bool) {

--- a/nvim/apiimp.go
+++ b/nvim/apiimp.go
@@ -1160,7 +1160,7 @@ func (b *Batch) CreateBuffer(listed bool, scratch bool, result *Buffer) {
 // this should not be used to specify arbitrary WM screen positions.
 //
 // The returns the window handle or 0 when error.
-func (v *Nvim) OpenWindow(buffer Buffer, enter bool, config *OpenWindowConfig) (Window, error) {
+func (v *Nvim) OpenWindow(buffer Buffer, enter bool, config *WindowConfig) (Window, error) {
 	var result Window
 	err := v.call("nvim_open_win", &result, buffer, enter, config)
 	return result, err
@@ -1191,7 +1191,7 @@ func (v *Nvim) OpenWindow(buffer Buffer, enter bool, config *OpenWindowConfig) (
 // this should not be used to specify arbitrary WM screen positions.
 //
 // The returns the window handle or 0 when error.
-func (b *Batch) OpenWindow(buffer Buffer, enter bool, config *OpenWindowConfig, result *Window) {
+func (b *Batch) OpenWindow(buffer Buffer, enter bool, config *WindowConfig, result *Window) {
 	b.call("nvim_open_win", result, buffer, enter, config)
 }
 

--- a/nvim/apitool.go
+++ b/nvim/apitool.go
@@ -301,7 +301,7 @@ var nvimTypes = map[string]string{
 	"*ClientVersion":           "Dictionary",
 	"ClientMethods":            "Dictionary",
 	"ClientAttributes":         "Dictionary",
-	"*OpenWindowConfig":        "Dictionary",
+	"*WindowConfig":            "Dictionary",
 
 	"[2]int":    "ArrayOf(Integer, 2)",
 	"[]Buffer":  "ArrayOf(Buffer)",

--- a/nvim/apitool.go
+++ b/nvim/apitool.go
@@ -301,6 +301,7 @@ var nvimTypes = map[string]string{
 	"*ClientVersion":           "Dictionary",
 	"ClientMethods":            "Dictionary",
 	"ClientAttributes":         "Dictionary",
+	"*OpenWindowConfig":        "Dictionary",
 
 	"[2]int":    "ArrayOf(Integer, 2)",
 	"[]Buffer":  "ArrayOf(Buffer)",

--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -515,6 +515,93 @@ func TestAPI(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
+
+	t.Run("floating_window", func(t *testing.T) {
+		clearBuffer(t, v, 0) // clear curret buffer text
+		curwin, err := v.CurrentWindow()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		wantWidth := 40
+		wantHeight := 20
+
+		cfg := &OpenWindowConfig{
+			Relative:  "cursor",
+			Anchor:    "NW",
+			Width:     wantWidth,
+			Height:    wantHeight,
+			Row:       1,
+			Col:       0,
+			Focusable: true,
+			Style:     "minimal",
+		}
+		w, err := v.OpenWindow(Buffer(0), true, cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if curwin == w {
+			t.Fatal("same window number: floating window not focused")
+		}
+
+		gotWidth, err := v.WindowWidth(w)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotWidth != wantWidth {
+			t.Fatalf("got %d width but want %d", gotWidth, wantWidth)
+		}
+
+		gotHeight, err := v.WindowHeight(w)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotHeight != wantHeight {
+			t.Fatalf("got %d height but want %d", gotHeight, wantHeight)
+		}
+
+		batch := v.NewBatch()
+		var (
+			numberOpt         bool
+			relativenumberOpt bool
+			cursorlineOpt     bool
+			cursorcolumnOpt   bool
+			spellOpt          bool
+			listOpt           bool
+			signcolumnOpt     string
+		)
+		batch.WindowOption(w, "number", &numberOpt)
+		batch.WindowOption(w, "relativenumber", &relativenumberOpt)
+		batch.WindowOption(w, "cursorline", &cursorlineOpt)
+		batch.WindowOption(w, "cursorcolumn", &cursorcolumnOpt)
+		batch.WindowOption(w, "spell", &spellOpt)
+		batch.WindowOption(w, "list", &listOpt)
+		batch.WindowOption(w, "signcolumn", &signcolumnOpt)
+		if err := batch.Execute(); err != nil {
+			t.Fatal(err)
+		}
+		if numberOpt {
+			t.Fatal("style is minimal; expected the number window option to disabled")
+		}
+		if relativenumberOpt {
+			t.Fatal("style is minimal; expected the relativenumber window option to disabled")
+		}
+		if cursorlineOpt {
+			t.Fatal("style is minimal; expected the cursorline window option to disabled")
+		}
+		if cursorcolumnOpt {
+			t.Fatal("style is minimal; expected the cursorcolumn window option to disabled")
+		}
+		if spellOpt {
+			t.Fatal("style is minimal; expected the spell window option to disabled")
+		}
+		if listOpt {
+			t.Fatal("style is minimal; expected the list window option to disabled")
+		}
+		if signcolumnOpt != "auto" {
+			t.Fatalf("style is minimal; got %q but expected the signcolumn window option to \"auto\"", signcolumnOpt)
+		}
+	})
 }
 
 func TestDial(t *testing.T) {

--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -580,26 +580,8 @@ func TestAPI(t *testing.T) {
 		if err := batch.Execute(); err != nil {
 			t.Fatal(err)
 		}
-		if numberOpt {
-			t.Fatal("style is minimal; expected the number window option to disabled")
-		}
-		if relativenumberOpt {
-			t.Fatal("style is minimal; expected the relativenumber window option to disabled")
-		}
-		if cursorlineOpt {
-			t.Fatal("style is minimal; expected the cursorline window option to disabled")
-		}
-		if cursorcolumnOpt {
-			t.Fatal("style is minimal; expected the cursorcolumn window option to disabled")
-		}
-		if spellOpt {
-			t.Fatal("style is minimal; expected the spell window option to disabled")
-		}
-		if listOpt {
-			t.Fatal("style is minimal; expected the list window option to disabled")
-		}
-		if signcolumnOpt != "auto" {
-			t.Fatalf("style is minimal; got %q but expected the signcolumn window option to \"auto\"", signcolumnOpt)
+		if numberOpt || relativenumberOpt || cursorlineOpt || cursorcolumnOpt || spellOpt || listOpt || signcolumnOpt != "auto" {
+			t.Fatal("expected minimal style")
 		}
 	})
 }

--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -526,7 +526,7 @@ func TestAPI(t *testing.T) {
 		wantWidth := 40
 		wantHeight := 20
 
-		cfg := &OpenWindowConfig{
+		cfg := &WindowConfig{
 			Relative:  "cursor",
 			Anchor:    "NW",
 			Width:     wantWidth,

--- a/nvim/types.go
+++ b/nvim/types.go
@@ -235,3 +235,60 @@ type VirtualTextChunk struct {
 	Text    string `msgpack:",array"`
 	HLGroup string `msgpack:",array"`
 }
+
+// OpenWindowConfig represents a configs of OpenWindow.
+//
+// Relative is the specifies the type of positioning method used for the floating window.
+// The positioning method keys names:
+//
+//  editor: The global editor grid.
+//  win: Window given by the `win` field, or current window by default.
+//  cursor: Cursor position in current window.
+//
+// Win is the Window for relative="win".
+//
+// Anchor is the decides which corner of the float to place at row and col.
+//
+//  NW: northwest (default)
+//  NE: northeast
+//  SW: southwest
+//  SE: southeast
+//
+// Width is the window width (in character cells). Minimum of 1.
+//
+// Height is the window height (in character cells). Minimum of 1.
+//
+// BufPos places float relative to buffer text only when relative="win". Takes a tuple of zero-indexed [line, column].
+// Row and Col if given are applied relative to this position, else they default to Row=1 and Col=0 (thus like a tooltip near the buffer text).
+//
+// Row is the row position in units of "screen cell height", may be fractional.
+//
+// Col is the column position in units of "screen cell width", may be fractional.
+//
+// Focusable whether the enable focus by user actions (wincmds, mouse events).
+// Defaults to true. Non-focusable windows can be entered by SetCurrentWindow.
+//
+// External is the GUI should display the window as an external top-level window.
+// Currently accepts no other positioning configuration together with this.
+//
+// Style is the Configure the appearance of the window.
+// Currently only takes one non-empty value:
+//
+//  minimal:
+//    Nvim will display the window with many UI options disabled.
+//    This is useful when displaying a temporary float where the text should not be edited.
+//    Disables 'number', 'relativenumber', 'cursorline', 'cursorcolumn','foldcolumn', 'spell' and 'list' options. 'signcolumn' is changed to `auto`.
+//    The end-of-buffer region is hidden by setting `eob` flag of 'fillchars' to a space char, and clearing the EndOfBuffer region in 'winhighlight'.
+type OpenWindowConfig struct {
+	Relative  string `msgpack:"relative,omitempty"`
+	Win       Window `msgpack:"win,omitempty"`
+	Anchor    string `msgpack:"anchor,omitempty" empty:"NW"`
+	Width     int    `msgpack:"width" empty:"1"`
+	Height    int    `msgpack:"height" empty:"1"`
+	BufPos    [2]int `msgpack:"bufpos,omitempty"`
+	Row       int    `msgpack:"row,omitempty"`
+	Col       int    `msgpack:"col,omitempty"`
+	Focusable bool   `msgpack:"focusable,omitempty" empty:"true"`
+	External  bool   `msgpack:"external,omitempty"`
+	Style     string `msgpack:"style,omitempty"`
+}

--- a/nvim/types.go
+++ b/nvim/types.go
@@ -236,7 +236,7 @@ type VirtualTextChunk struct {
 	HLGroup string `msgpack:",array"`
 }
 
-// OpenWindowConfig represents a configs of OpenWindow.
+// WindowConfig represents a configs of OpenWindow.
 //
 // Relative is the specifies the type of positioning method used for the floating window.
 // The positioning method keys names:
@@ -279,7 +279,7 @@ type VirtualTextChunk struct {
 //    This is useful when displaying a temporary float where the text should not be edited.
 //    Disables 'number', 'relativenumber', 'cursorline', 'cursorcolumn','foldcolumn', 'spell' and 'list' options. 'signcolumn' is changed to `auto`.
 //    The end-of-buffer region is hidden by setting `eob` flag of 'fillchars' to a space char, and clearing the EndOfBuffer region in 'winhighlight'.
-type OpenWindowConfig struct {
+type WindowConfig struct {
 	Relative  string `msgpack:"relative,omitempty"`
 	Win       Window `msgpack:"win,omitempty"`
 	Anchor    string `msgpack:"anchor,omitempty" empty:"NW"`


### PR DESCRIPTION
Add `WindowConfig` struct for `OpenWindow` API instead of `map[string]interface`.
Also, added `floating_window` testcase.

Close: #54