### PR TITLE
Implements neovim/neovim@7ce9a5c7da0f API (`nvim_get_runtime_file `)

### DIFF
--- a/nvim/apidef.go
+++ b/nvim/apidef.go
@@ -476,6 +476,19 @@ func RuntimePaths() []string {
 	name(nvim_list_runtime_paths)
 }
 
+// RuntimeFiles finds files in runtime directories and returns list of absolute paths to the found files.
+//
+//  name
+// can contain wildcards. For example
+//  nvim_get_runtime_file("colors/*.vim", true)
+// will return all color scheme files.
+//
+//  all
+// whether to return all matches or only the first.
+func RuntimeFiles(name string, all bool) []string {
+	name(nvim_get_runtime_file)
+}
+
 // SetCurrentDirectory changes the Vim working directory.
 func SetCurrentDirectory(dir string) {
 	name(nvim_set_current_dir)

--- a/nvim/apiimp.go
+++ b/nvim/apiimp.go
@@ -1077,6 +1077,34 @@ func (b *Batch) RuntimePaths(result *[]string) {
 	b.call("nvim_list_runtime_paths", result)
 }
 
+// RuntimeFiles finds files in runtime directories and returns list of absolute paths to the found files.
+//
+//  name
+// can contain wildcards. For example
+//  nvim_get_runtime_file("colors/*.vim", true)
+// will return all color scheme files.
+//
+//  all
+// whether to return all matches or only the first.
+func (v *Nvim) RuntimeFiles(name string, all bool) ([]string, error) {
+	var result []string
+	err := v.call("nvim_get_runtime_file", &result, name, all)
+	return result, err
+}
+
+// RuntimeFiles finds files in runtime directories and returns list of absolute paths to the found files.
+//
+//  name
+// can contain wildcards. For example
+//  nvim_get_runtime_file("colors/*.vim", true)
+// will return all color scheme files.
+//
+//  all
+// whether to return all matches or only the first.
+func (b *Batch) RuntimeFiles(name string, all bool, result *[]string) {
+	b.call("nvim_get_runtime_file", result, name, all)
+}
+
 // SetCurrentDirectory changes the Vim working directory.
 func (v *Nvim) SetCurrentDirectory(dir string) error {
 	return v.call("nvim_set_current_dir", nil, dir)

--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"path/filepath"
 	"reflect"
+	"sort"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -665,6 +667,27 @@ func TestAPI(t *testing.T) {
 
 		if err := v.ClearBufferNamespace(Buffer(0), nsID, 0, -1); err != nil {
 			t.Fatal(err)
+		}
+	})
+
+	t.Run("runtime_file", func(t *testing.T) {
+		files, err := v.RuntimeFiles("doc/*_diff.txt", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		sort.Strings(files)
+		if len(files) != 2 {
+			t.Fatalf("expected 2 length but got %d", len(files))
+		}
+
+		var runtimePath string
+		if err := v.Eval("$VIMRUNTIME", &runtimePath); err != nil {
+			t.Fatal(err)
+		}
+
+		want := fmt.Sprintf("%s,%s", filepath.Join(runtimePath, "doc", "vi_diff.txt"), filepath.Join(runtimePath, "doc", "vim_diff.txt"))
+		if got := strings.Join(files, ","); !strings.EqualFold(got, want) {
+			t.Fatalf("got %s but want %s", got, want)
 		}
 	})
 }


### PR DESCRIPTION
Implements neovim/neovim@7ce9a5c7da0f API , actually `nvim_get_runtime_file`.

Also, added testcase.