### PR TITLE
If CommandCompletionArgs.CursorPosString is a string, and not at int,

### DIFF
--- a/nvim/helpers.go
+++ b/nvim/helpers.go
@@ -2,7 +2,6 @@ package nvim
 
 import (
 	"io"
-	"strconv"
 )
 
 // QuickfixError represents an item in a quickfix list.
@@ -55,12 +54,12 @@ type CommandCompletionArgs struct {
 
 	// CursorPosString is decimal representation of the cursor position in
 	// bytes.
-	CursorPosString string
+	CursorPosString int
 }
 
 // CursorPos returns the cursor position.
 func (a *CommandCompletionArgs) CursorPos() int {
-	n, _ := strconv.Atoi(a.CursorPosString)
+	n := a.CursorPosString
 	return n
 }
 


### PR DESCRIPTION
msgpack consistently errors out saying it cannot convert an 'int to a
string'. If you change it to an int it works as expected.