### PR TITLE
nvim: add deprecatedSince(7) to `ClearBufferHighlight`, add `AllOptionsInfo` and `OptionInfo`

### DIFF
--- a/nvim/apidef.go
+++ b/nvim/apidef.go
@@ -570,6 +570,75 @@ func SetVVar(name string, value interface{}) {
 	name(nvim_set_vvar)
 }
 
+// AllOptionsInfo gets the option information for all options.
+//
+// The dictionary has the full option names as keys and option metadata
+// dictionaries as detailed at `nvim_get_option_info`.
+//
+// Resulting map has keys:
+//
+//  name
+// Name of the option (like 'filetype').
+//  shortname
+// Shortened name of the option (like 'ft').
+//  type
+// type of option ("string", "integer" or "boolean").
+//  default
+// The default value for the option.
+//  was_set
+// Whether the option was set.
+//  last_set_sid
+// Last set script id (if any).
+//  last_set_linenr
+// line number where option was set.
+//  last_set_chan
+// Channel where option was set (0 for local).
+//  scope
+// one of "global", "win", or "buf".
+//  global_local
+// whether win or buf option has a global value.
+//  commalist
+// List of comma separated values.
+//  flaglist
+// List of single char flags.
+func AllOptionsInfo() OptionInfo {
+	name(nvim_get_all_options_info)
+	returnPtr()
+}
+
+// OptionInfo Gets the option information for one option.
+//
+// Resulting dictionary has keys:
+//
+//  name
+// Name of the option (like 'filetype').
+//  shortname
+// Shortened name of the option (like 'ft').
+//  type
+// type of option ("string", "integer" or "boolean").
+//  default
+// The default value for the option.
+//  was_set
+// Whether the option was set.
+//  last_set_sid
+// Last set script id (if any).
+//  last_set_linenr
+// line number where option was set.
+//  last_set_chan
+// Channel where option was set (0 for local).
+//  scope
+// one of "global", "win", or "buf".
+//  global_local
+// whether win or buf option has a global value.
+//  commalist
+// List of comma separated values.
+//  flaglist
+//  List of single char flags.
+func OptionInfo(name string) OptionInfo {
+	name(nvim_get_option_info)
+	returnPtr()
+}
+
 // Option gets an option.
 func Option(name string) interface{} {
 	name(nvim_get_option)

--- a/nvim/apidef.go
+++ b/nvim/apidef.go
@@ -274,6 +274,7 @@ func ClearBufferNamespace(buffer Buffer, nsID int, lineStart int, lineEnd int) {
 // Deprecated: Use ClearBufferNamespace() instead.
 func ClearBufferHighlight(buffer Buffer, srcID int, startLine int, endLine int) {
 	name(nvim_buf_clear_highlight)
+	deprecatedSince(7)
 }
 
 // SetBufferVirtualText sets the virtual text (annotation) for a buffer line.

--- a/nvim/apiimp.go
+++ b/nvim/apiimp.go
@@ -1265,6 +1265,144 @@ func (b *Batch) SetVVar(name string, value interface{}) {
 	b.call("nvim_set_vvar", nil, name, value)
 }
 
+// AllOptionsInfo gets the option information for all options.
+//
+// The dictionary has the full option names as keys and option metadata
+// dictionaries as detailed at `nvim_get_option_info`.
+//
+// Resulting map has keys:
+//
+//  name
+// Name of the option (like 'filetype').
+//  shortname
+// Shortened name of the option (like 'ft').
+//  type
+// type of option ("string", "integer" or "boolean").
+//  default
+// The default value for the option.
+//  was_set
+// Whether the option was set.
+//  last_set_sid
+// Last set script id (if any).
+//  last_set_linenr
+// line number where option was set.
+//  last_set_chan
+// Channel where option was set (0 for local).
+//  scope
+// one of "global", "win", or "buf".
+//  global_local
+// whether win or buf option has a global value.
+//  commalist
+// List of comma separated values.
+//  flaglist
+// List of single char flags.
+func (v *Nvim) AllOptionsInfo() (*OptionInfo, error) {
+	var result OptionInfo
+	err := v.call("nvim_get_all_options_info", &result)
+	return &result, err
+}
+
+// AllOptionsInfo gets the option information for all options.
+//
+// The dictionary has the full option names as keys and option metadata
+// dictionaries as detailed at `nvim_get_option_info`.
+//
+// Resulting map has keys:
+//
+//  name
+// Name of the option (like 'filetype').
+//  shortname
+// Shortened name of the option (like 'ft').
+//  type
+// type of option ("string", "integer" or "boolean").
+//  default
+// The default value for the option.
+//  was_set
+// Whether the option was set.
+//  last_set_sid
+// Last set script id (if any).
+//  last_set_linenr
+// line number where option was set.
+//  last_set_chan
+// Channel where option was set (0 for local).
+//  scope
+// one of "global", "win", or "buf".
+//  global_local
+// whether win or buf option has a global value.
+//  commalist
+// List of comma separated values.
+//  flaglist
+// List of single char flags.
+func (b *Batch) AllOptionsInfo(result *OptionInfo) {
+	b.call("nvim_get_all_options_info", result)
+}
+
+// OptionInfo Gets the option information for one option.
+//
+// Resulting dictionary has keys:
+//
+//  name
+// Name of the option (like 'filetype').
+//  shortname
+// Shortened name of the option (like 'ft').
+//  type
+// type of option ("string", "integer" or "boolean").
+//  default
+// The default value for the option.
+//  was_set
+// Whether the option was set.
+//  last_set_sid
+// Last set script id (if any).
+//  last_set_linenr
+// line number where option was set.
+//  last_set_chan
+// Channel where option was set (0 for local).
+//  scope
+// one of "global", "win", or "buf".
+//  global_local
+// whether win or buf option has a global value.
+//  commalist
+// List of comma separated values.
+//  flaglist
+//  List of single char flags.
+func (v *Nvim) OptionInfo(name string) (*OptionInfo, error) {
+	var result OptionInfo
+	err := v.call("nvim_get_option_info", &result, name)
+	return &result, err
+}
+
+// OptionInfo Gets the option information for one option.
+//
+// Resulting dictionary has keys:
+//
+//  name
+// Name of the option (like 'filetype').
+//  shortname
+// Shortened name of the option (like 'ft').
+//  type
+// type of option ("string", "integer" or "boolean").
+//  default
+// The default value for the option.
+//  was_set
+// Whether the option was set.
+//  last_set_sid
+// Last set script id (if any).
+//  last_set_linenr
+// line number where option was set.
+//  last_set_chan
+// Channel where option was set (0 for local).
+//  scope
+// one of "global", "win", or "buf".
+//  global_local
+// whether win or buf option has a global value.
+//  commalist
+// List of comma separated values.
+//  flaglist
+//  List of single char flags.
+func (b *Batch) OptionInfo(name string, result *OptionInfo) {
+	b.call("nvim_get_option_info", result, name)
+}
+
 // Option gets an option.
 func (v *Nvim) Option(name string, result interface{}) error {
 	return v.call("nvim_get_option", result, name)

--- a/nvim/apitool.go
+++ b/nvim/apitool.go
@@ -307,6 +307,7 @@ var nvimTypes = map[string]string{
 	"map[string]int":           "Dictionary",
 	"map[string]interface{}":   "Dictionary",
 	"Mode":                     "Dictionary",
+	"OptionInfo":               "Dictionary",
 
 	"[]*Channel":         "Array",
 	"[]*Process":         "Array",

--- a/nvim/types.go
+++ b/nvim/types.go
@@ -299,3 +299,42 @@ type ExtMarks struct {
 	Row       int
 	Col       int
 }
+
+// OptionInfo represents a option information.
+type OptionInfo struct {
+	// Name is the name of the option (like 'filetype').
+	Name string `msgpack:"name"`
+
+	// ShortName is the shortened name of the option (like 'ft').
+	ShortName string `msgpack:"shortname"`
+
+	// Type is the type of option ("string", "number" or "boolean").
+	Type string `msgpack:"type"`
+
+	// Default is the default value for the option.
+	Default interface{} `msgpack:"default"`
+
+	// WasSet whether the option was set.
+	WasSet bool `msgpack:"was_set"`
+
+	// LastSetSid is the last set script id (if any).
+	LastSetSid int `msgpack:"last_set_sid"`
+
+	// LastSetLinenr is the line number where option was set.
+	LastSetLinenr int `msgpack:"last_set_linenr"`
+
+	// LastSetChan is the channel where option was set (0 for local).
+	LastSetChan int `msgpack:"last_set_chan"`
+
+	// Scope one of "global", "win", or "buf".
+	Scope string `msgpack:"scope"`
+
+	// GlobalLocal whether win or buf option has a global value.
+	GlobalLocal bool `msgpack:"global_local"`
+
+	// CommaList whether the list of comma separated values.
+	CommaList bool `msgpack:"commalist"`
+
+	// FlagList whether the list of single char flags.
+	FlagList bool `msgpack:"flaglist"`
+}


### PR DESCRIPTION
- add `deprecatedSince(7)` to `ClearBufferHighlight`
- add `AllOptionsInfo` and `OptionInfo` methods