### PR TITLE
nvim: add SetBufferText and Echo apis

### DIFF
--- a/nvim/api.go
+++ b/nvim/api.go
@@ -201,6 +201,40 @@ func (b *Batch) SetBufferLines(buffer Buffer, start int, end int, strict bool, r
 	b.call("nvim_buf_set_lines", nil, buffer, start, end, strict, replacement)
 }
 
+// SetBufferText sets or replaces a range in the buffer.
+//
+// This is recommended over SetBufferLines when only modifying parts of a
+// line, as extmarks will be preserved on non-modified parts of the touched
+// lines.
+//
+// Indexing is zero-based and end-exclusive.
+//
+// To insert text at a given index, set `start` and `end` ranges to the same
+// index. To delete a range, set `replacement` to an array containing
+// an empty string, or simply an empty array.
+//
+// Prefer SetBufferLines when adding or deleting entire lines only.
+func (v *Nvim) SetBufferText(buffer Buffer, startRow int, startCol int, endRow int, endCol int, replacement [][]byte) error {
+	return v.call("nvim_buf_set_text", nil, buffer, startRow, startCol, endRow, endCol, replacement)
+}
+
+// SetBufferText sets or replaces a range in the buffer.
+//
+// This is recommended over SetBufferLines when only modifying parts of a
+// line, as extmarks will be preserved on non-modified parts of the touched
+// lines.
+//
+// Indexing is zero-based and end-exclusive.
+//
+// To insert text at a given index, set `start` and `end` ranges to the same
+// index. To delete a range, set `replacement` to an array containing
+// an empty string, or simply an empty array.
+//
+// Prefer SetBufferLines when adding or deleting entire lines only.
+func (b *Batch) SetBufferText(buffer Buffer, startRow int, startCol int, endRow int, endCol int, replacement [][]byte) {
+	b.call("nvim_buf_set_text", nil, buffer, startRow, startCol, endRow, endCol, replacement)
+}
+
 // BufferOffset returns the byte offset for a line.
 //
 // Line 1 (index=0) has offset 0. UTF-8 bytes are counted. EOL is one byte.
@@ -1478,6 +1512,30 @@ func (v *Nvim) SetOption(name string, value interface{}) error {
 // SetOption sets an option.
 func (b *Batch) SetOption(name string, value interface{}) {
 	b.call("nvim_set_option", nil, name, value)
+}
+
+// Echo echo a message.
+//
+// The chunks is a list of [text, hl_group] arrays, each representing a
+// text chunk with specified highlight. hl_group element can be omitted for no highlight.
+//
+// If history is true, add to |message-history|.
+//
+// The opts arg is optional parameters. Reserved for future use.
+func (v *Nvim) Echo(chunks []EchoChunk, history bool, opts map[string]interface{}) error {
+	return v.call("nvim_echo", nil, chunks, history, opts)
+}
+
+// Echo echo a message.
+//
+// The chunks is a list of [text, hl_group] arrays, each representing a
+// text chunk with specified highlight. hl_group element can be omitted for no highlight.
+//
+// If history is true, add to |message-history|.
+//
+// The opts arg is optional parameters. Reserved for future use.
+func (b *Batch) Echo(chunks []EchoChunk, history bool, opts map[string]interface{}) {
+	b.call("nvim_echo", nil, chunks, history, opts)
 }
 
 // WriteOut writes a message to vim output buffer. The string is split and

--- a/nvim/api_def.go
+++ b/nvim/api_def.go
@@ -63,6 +63,23 @@ func SetBufferLines(buffer Buffer, start int, end int, strict bool, replacement 
 	name(nvim_buf_set_lines)
 }
 
+// SetBufferText sets or replaces a range in the buffer.
+//
+// This is recommended over SetBufferLines when only modifying parts of a
+// line, as extmarks will be preserved on non-modified parts of the touched
+// lines.
+//
+// Indexing is zero-based and end-exclusive.
+//
+// To insert text at a given index, set `start` and `end` ranges to the same
+// index. To delete a range, set `replacement` to an array containing
+// an empty string, or simply an empty array.
+//
+// Prefer SetBufferLines when adding or deleting entire lines only.
+func SetBufferText(buffer Buffer, startRow, startCol, endRow, endCol int, replacement [][]byte) {
+	name(nvim_buf_set_text)
+}
+
 // BufferOffset returns the byte offset for a line.
 //
 // Line 1 (index=0) has offset 0. UTF-8 bytes are counted. EOL is one byte.
@@ -688,6 +705,18 @@ func Option(name string) (option interface{}) {
 // SetOption sets an option.
 func SetOption(name string, value interface{}) {
 	name(nvim_set_option)
+}
+
+// Echo echo a message.
+//
+// The chunks is a list of [text, hl_group] arrays, each representing a
+// text chunk with specified highlight. hl_group element can be omitted for no highlight.
+//
+// If history is true, add to |message-history|.
+//
+// The opts arg is optional parameters. Reserved for future use.
+func Echo(chunks []EchoChunk, history bool, opts map[string]interface{}) {
+	name(nvim_echo)
 }
 
 // WriteOut writes a message to vim output buffer. The string is split and

--- a/nvim/api_tool.go
+++ b/nvim/api_tool.go
@@ -372,6 +372,7 @@ var nvimTypes = map[string]string{
 	"[]*UI":              "Array",
 	"[]ExtMarks":         "Array",
 	"[]VirtualTextChunk": "Array",
+	"[]EchoChunk":        "Array",
 
 	"[2]int":     "ArrayOf(Integer, 2)",
 	"[]*Mapping": "ArrayOf(Dictionary)",

--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -92,6 +92,7 @@ func TestAPI(t *testing.T) {
 	t.Run("Tabpage", testTabpage(v))
 	t.Run("Lines", testLines(v))
 	t.Run("Var", testVar(v))
+	t.Run("Message", testMessage(v))
 	t.Run("StructValue", testStructValue(v))
 	t.Run("Eval", testEval(v))
 	t.Run("Batch", testBatch(v))
@@ -879,6 +880,143 @@ func testVar(v *Nvim) func(*testing.T) {
 			}
 			if value != "" {
 				t.Fatalf("got %v, want %q", value, "")
+			}
+		})
+	}
+}
+
+func testMessage(v *Nvim) func(*testing.T) {
+	return func(t *testing.T) {
+		t.Run("Nvim", func(t *testing.T) {
+			const wantWriteOut = `hello WriteOut`
+			if err := v.WriteOut(wantWriteOut + "\n"); err != nil {
+				t.Fatalf("failed to WriteOut: %v", err)
+			}
+
+			var gotWriteOut string
+			if err := v.VVar("statusmsg", &gotWriteOut); err != nil {
+				t.Fatalf("could not get v:statusmsg nvim variable: %v", err)
+			}
+			if gotWriteOut != wantWriteOut {
+				t.Fatalf("WriteOut(%q) = %q, want: %q", wantWriteOut, gotWriteOut, wantWriteOut)
+			}
+
+			// cleanup v:statusmsg
+			if err := v.SetVVar("statusmsg", ""); err != nil {
+				t.Fatalf("failed to SetVVar: %v", err)
+			}
+
+			// clear messages
+			if _, err := v.Exec(":messages clear", false); err != nil {
+				t.Fatalf("failed to SetVVar: %v", err)
+			}
+
+			const wantWriteErr = `hello WriteErr`
+			if err := v.WriteErr(wantWriteErr + "\n"); err != nil {
+				t.Fatalf("failed to WriteErr: %v", err)
+			}
+
+			var gotWriteErr string
+			if err := v.VVar("errmsg", &gotWriteErr); err != nil {
+				t.Fatalf("could not get v:statusmsg nvim variable: %v", err)
+			}
+			if gotWriteErr != wantWriteErr {
+				t.Fatalf("WriteErr(%q) = %q, want: %q", wantWriteErr, gotWriteErr, wantWriteErr)
+			}
+
+			// cleanup v:statusmsg
+			if err := v.SetVVar("statusmsg", ""); err != nil {
+				t.Fatalf("failed to SetVVar: %v", err)
+			}
+
+			// clear messages
+			if _, err := v.Exec(":messages clear", false); err != nil {
+				t.Fatalf("failed to SetVVar: %v", err)
+			}
+
+			const wantWritelnErr = `hello WritelnErr`
+			if err := v.WritelnErr(wantWritelnErr); err != nil {
+				t.Fatalf("failed to WriteErr: %v", err)
+			}
+
+			var gotWritelnErr string
+			if err := v.VVar("errmsg", &gotWritelnErr); err != nil {
+				t.Fatalf("could not get v:statusmsg nvim variable: %v", err)
+			}
+			if gotWritelnErr != wantWritelnErr {
+				t.Fatalf("WritelnErr(%q) = %q, want: %q", wantWritelnErr, gotWritelnErr, wantWritelnErr)
+			}
+
+			// cleanup v:statusmsg
+			if err := v.SetVVar("statusmsg", ""); err != nil {
+				t.Fatalf("failed to SetVVar: %v", err)
+			}
+
+			// clear messages
+			if _, err := v.Exec(":messages clear", false); err != nil {
+				t.Fatalf("failed to SetVVar: %v", err)
+			}
+		})
+
+		t.Run("Batch", func(t *testing.T) {
+			b := v.NewBatch()
+
+			const wantWriteOut = `hello WriteOut`
+			b.WriteOut(wantWriteOut + "\n")
+			if err := b.Execute(); err != nil {
+				t.Fatalf("failed to WriteOut: %v", err)
+			}
+
+			var gotWriteOut string
+			b.VVar("statusmsg", &gotWriteOut)
+			if err := b.Execute(); err != nil {
+				t.Fatalf("could not get v:statusmsg nvim variable: %v", err)
+			}
+			if gotWriteOut != wantWriteOut {
+				t.Fatalf("b.WriteOut(%q) = %q, want: %q", wantWriteOut, gotWriteOut, wantWriteOut)
+			}
+
+			// cleanup v:statusmsg
+			if err := v.SetVVar("statusmsg", ""); err != nil {
+				t.Fatalf("failed to SetVVar: %v", err)
+			}
+
+			const wantWriteErr = `hello WriteErr`
+			b.WriteErr(wantWriteErr + "\n")
+			if err := b.Execute(); err != nil {
+				t.Fatalf("failed to WriteErr: %v", err)
+			}
+			var gotWriteErr string
+			b.VVar("errmsg", &gotWriteErr)
+			if err := b.Execute(); err != nil {
+				t.Fatalf("could not get v:statusmsg nvim variable: %v", err)
+			}
+			if gotWriteErr != wantWriteErr {
+				t.Fatalf("b.WriteErr(%q) = %q, want: %q", wantWriteErr, gotWriteErr, wantWriteErr)
+			}
+
+			// cleanup v:statusmsg
+			if err := v.SetVVar("statusmsg", ""); err != nil {
+				t.Fatalf("failed to SetVVar: %v", err)
+			}
+
+			const wantWritelnErr = `hello WritelnErr`
+			b.WritelnErr(wantWritelnErr)
+			if err := b.Execute(); err != nil {
+				t.Fatalf("failed to WriteErr: %v", err)
+			}
+			var gotWritelnErr string
+			b.VVar("errmsg", &gotWritelnErr)
+			if err := b.Execute(); err != nil {
+				t.Fatalf("could not get v:statusmsg nvim variable: %v", err)
+			}
+			if gotWritelnErr != wantWritelnErr {
+				t.Fatalf("b.WritelnErr(%q) = %q, want: %q", wantWritelnErr, gotWritelnErr, wantWritelnErr)
+			}
+
+			// cleanup v:statusmsg
+			if err := v.SetVVar("statusmsg", ""); err != nil {
+				t.Fatalf("failed to SetVVar: %v", err)
 			}
 		})
 	}

--- a/nvim/types.go
+++ b/nvim/types.go
@@ -356,6 +356,15 @@ type VirtualTextChunk struct {
 	HLGroup string
 }
 
+// EchoChunk represents a echo chunk.
+type EchoChunk struct {
+	// Text is echo text.
+	Text string `msgpack:",array"`
+
+	// HLGroup is echo highlight group.
+	HLGroup string
+}
+
 // WindowConfig represents a configs of OpenWindow.
 //
 // Relative is the specifies the type of positioning method used for the floating window.


### PR DESCRIPTION
Add `SetBufferText` and `Echo` apis.

```
> nvim_buf_set_text(buffer Buffer, start_row Integer, start_col Integer, end_row Integer, end_col Integer, replacement ArrayOf(String)) void { name(nvim_buf_set_text) }
> nvim_echo(chunks Array, history Boolean, opts Dictionary) void { name(nvim_echo) }
```