### PR TITLE
nvim: rename some type names

### DIFF
--- a/nvim/api.go
+++ b/nvim/api.go
@@ -94,7 +94,6 @@ func (x Window) String() string {
 }
 
 // Exec executes Vimscript (multiline block of Ex-commands), like anonymous source.
-// Exec executes Vimscript (multiline block of Ex-commands), like anonymous |:source|.
 //
 // Unlike Command, this function supports heredocs, script-scope (s:), etc.
 //
@@ -105,7 +104,6 @@ func (v *Nvim) Exec(src string, output bool) (out string, err error) {
 }
 
 // Exec executes Vimscript (multiline block of Ex-commands), like anonymous source.
-// Exec executes Vimscript (multiline block of Ex-commands), like anonymous |:source|.
 //
 // Unlike Command, this function supports heredocs, script-scope (s:), etc.
 //

--- a/nvim/api.go
+++ b/nvim/api.go
@@ -1933,7 +1933,7 @@ func (b *Batch) BufferExtmarkByID(buffer Buffer, nsID int, id int, opt map[strin
 //
 //  details
 // Whether to include the details dict. bool type.
-func (v *Nvim) BufferExtmarks(buffer Buffer, nsID int, start interface{}, end interface{}, opt map[string]interface{}) (marks []ExtMarks, err error) {
+func (v *Nvim) BufferExtmarks(buffer Buffer, nsID int, start interface{}, end interface{}, opt map[string]interface{}) (marks []ExtMark, err error) {
 	err = v.call("nvim_buf_get_extmarks", &marks, buffer, nsID, start, end, opt)
 	return marks, err
 }
@@ -1961,7 +1961,7 @@ func (v *Nvim) BufferExtmarks(buffer Buffer, nsID int, start interface{}, end in
 //
 //  details
 // Whether to include the details dict. bool type.
-func (b *Batch) BufferExtmarks(buffer Buffer, nsID int, start interface{}, end interface{}, opt map[string]interface{}, marks *[]ExtMarks) {
+func (b *Batch) BufferExtmarks(buffer Buffer, nsID int, start interface{}, end interface{}, opt map[string]interface{}, marks *[]ExtMark) {
 	b.call("nvim_buf_get_extmarks", marks, buffer, nsID, start, end, opt)
 }
 

--- a/nvim/api.go
+++ b/nvim/api.go
@@ -710,7 +710,7 @@ func (b *Batch) SetOption(name string, value interface{}) {
 // If history is true, add to |message-history|.
 //
 // The opts arg is optional parameters. Reserved for future use.
-func (v *Nvim) Echo(chunks []EchoChunk, history bool, opts map[string]interface{}) error {
+func (v *Nvim) Echo(chunks []TextChunk, history bool, opts map[string]interface{}) error {
 	return v.call("nvim_echo", nil, chunks, history, opts)
 }
 
@@ -722,7 +722,7 @@ func (v *Nvim) Echo(chunks []EchoChunk, history bool, opts map[string]interface{
 // If history is true, add to |message-history|.
 //
 // The opts arg is optional parameters. Reserved for future use.
-func (b *Batch) Echo(chunks []EchoChunk, history bool, opts map[string]interface{}) {
+func (b *Batch) Echo(chunks []TextChunk, history bool, opts map[string]interface{}) {
 	b.call("nvim_echo", nil, chunks, history, opts)
 }
 
@@ -1992,7 +1992,7 @@ func (b *Batch) BufferExtmarks(buffer Buffer, nsID int, start interface{}, end i
 // Name ar ID of the highlight group used to highlight this mark. string or int type.
 //
 //  virt_text
-// virtual text to link to this mark. VirtualTextChunk type.
+// virtual text to link to this mark. TextChunk type.
 //
 //  ephemeral
 // For use with SetDecorationProvider callbacks. bool type.
@@ -2029,7 +2029,7 @@ func (v *Nvim) SetBufferExtmark(buffer Buffer, nsID int, line int, col int, opts
 // Name ar ID of the highlight group used to highlight this mark. string or int type.
 //
 //  virt_text
-// virtual text to link to this mark. VirtualTextChunk type.
+// virtual text to link to this mark. TextChunk type.
 //
 //  ephemeral
 // For use with SetDecorationProvider callbacks. bool type.
@@ -2163,7 +2163,7 @@ func (b *Batch) ClearBufferHighlight(buffer Buffer, srcID int, startLine int, en
 // virtual text, the allocated id is then returned.
 //
 // The opts arg is reserved for future use.
-func (v *Nvim) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []VirtualTextChunk, opts map[string]interface{}) (id int, err error) {
+func (v *Nvim) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []TextChunk, opts map[string]interface{}) (id int, err error) {
 	err = v.call("nvim_buf_set_virtual_text", &id, buffer, nsID, line, chunks, opts)
 	return id, err
 }
@@ -2187,7 +2187,7 @@ func (v *Nvim) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []
 // virtual text, the allocated id is then returned.
 //
 // The opts arg is reserved for future use.
-func (b *Batch) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []VirtualTextChunk, opts map[string]interface{}, id *int) {
+func (b *Batch) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks []TextChunk, opts map[string]interface{}, id *int) {
 	b.call("nvim_buf_set_virtual_text", id, buffer, nsID, line, chunks, opts)
 }
 

--- a/nvim/api_def.go
+++ b/nvim/api_def.go
@@ -927,7 +927,7 @@ func BufferExtmarkByID(buffer Buffer, nsID, id int, opt map[string]interface{}) 
 //
 //  details
 // Whether to include the details dict. bool type.
-func BufferExtmarks(buffer Buffer, nsID int, start, end interface{}, opt map[string]interface{}) (marks []ExtMarks) {
+func BufferExtmarks(buffer Buffer, nsID int, start, end interface{}, opt map[string]interface{}) (marks []ExtMark) {
 	name(nvim_buf_get_extmarks)
 }
 

--- a/nvim/api_def.go
+++ b/nvim/api_def.go
@@ -14,7 +14,6 @@ package main
 // vim.c
 
 // Exec executes Vimscript (multiline block of Ex-commands), like anonymous source.
-// Exec executes Vimscript (multiline block of Ex-commands), like anonymous |:source|.
 //
 // Unlike Command, this function supports heredocs, script-scope (s:), etc.
 //

--- a/nvim/api_def.go
+++ b/nvim/api_def.go
@@ -322,7 +322,7 @@ func SetOption(name string, value interface{}) {
 // If history is true, add to |message-history|.
 //
 // The opts arg is optional parameters. Reserved for future use.
-func Echo(chunks []EchoChunk, history bool, opts map[string]interface{}) {
+func Echo(chunks []TextChunk, history bool, opts map[string]interface{}) {
 	name(nvim_echo)
 }
 
@@ -958,7 +958,7 @@ func BufferExtmarks(buffer Buffer, nsID int, start, end interface{}, opt map[str
 // Name ar ID of the highlight group used to highlight this mark. string or int type.
 //
 //  virt_text
-// virtual text to link to this mark. VirtualTextChunk type.
+// virtual text to link to this mark. TextChunk type.
 //
 //  ephemeral
 // For use with SetDecorationProvider callbacks. bool type.
@@ -1039,7 +1039,7 @@ func ClearBufferHighlight(buffer Buffer, srcID, startLine, endLine int) {
 // virtual text, the allocated id is then returned.
 //
 // The opts arg is reserved for future use.
-func SetBufferVirtualText(buffer Buffer, nsID, line int, chunks []VirtualTextChunk, opts map[string]interface{}) (id int) {
+func SetBufferVirtualText(buffer Buffer, nsID, line int, chunks []TextChunk, opts map[string]interface{}) (id int) {
 	name(nvim_buf_set_virtual_text)
 }
 

--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -1466,7 +1466,7 @@ func testVirtualText(v *Nvim) func(*testing.T) {
 			t.Fatal(err)
 		}
 
-		chunks := []VirtualTextChunk{
+		chunks := []TextChunk{
 			{
 				Text:    "pong",
 				HLGroup: "String",

--- a/nvim/types.go
+++ b/nvim/types.go
@@ -440,8 +440,8 @@ type WindowConfig struct {
 	Style string `msgpack:"style,omitempty"`
 }
 
-// ExtMarks represents a extmarks type.
-type ExtMarks struct {
+// ExtMark represents a extmarks type.
+type ExtMark struct {
 	// ID is the extmarks ID.
 	ID int `msgpack:",array"`
 

--- a/nvim/types.go
+++ b/nvim/types.go
@@ -347,21 +347,12 @@ type Command struct {
 	Definition string `msgpack:"definition"`
 }
 
-// VirtualTextChunk represents a virtual text chunk.
-type VirtualTextChunk struct {
-	// Text is VirtualText text.
+// TextChunk represents a text chunk.
+type TextChunk struct {
+	// Text is text.
 	Text string `msgpack:",array"`
 
-	// HLGroup is VirtualText highlight group.
-	HLGroup string
-}
-
-// EchoChunk represents a echo chunk.
-type EchoChunk struct {
-	// Text is echo text.
-	Text string `msgpack:",array"`
-
-	// HLGroup is echo highlight group.
+	// HLGroup is text highlight group.
 	HLGroup string
 }
 


### PR DESCRIPTION
Rename some type names.

- VirtualTextChunk and EchoChunk to TextChunk
- rename ExtMarks to ExtMark