### PR TITLE
github/workflow: fix codeql checkout fetch-depth to 2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@main
+      with:
+        fetch-depth: 2
 
     - name: Install Go
       uses: actions/setup-go@main


### PR DESCRIPTION
Fix CodeQL checkout fetch-depth to `2`.