### PR TITLE
github/workflow: temporary use neovim v0.5.0 instead of nighly

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -61,7 +61,7 @@ jobs:
       if: steps.cache-nvim.outputs.cache-hit != 'true'
       with:
         neovim: true
-        version: nightly
+        version: v0.5.0
 
     - name: Run Benchmark
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04  # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
-          - macos-11.0    # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11.0-Readme.md
+          - macos-11.0    # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
           - windows-2019  # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md
         go-version:
           - 1.14.x
@@ -66,7 +66,7 @@ jobs:
       if: steps.cache-nvim.outputs.cache-hit != 'true' || steps.cache-nvim-windows.outputs.cache-hit != 'true'
       with:
         neovim: true
-        version: nightly
+        version: v0.5.0
 
     - name: gofmt
       if: ${{ env.OS != 'windows' }}


### PR DESCRIPTION
Temporary use neovim `v0.5.0` instead of nighly.

ref: https://github.com/rhysd/action-setup-vim/issues/17