### PR TITLE
nvim: fix UserCommand to non pointer on nvimTypes

### DIFF
--- a/nvim/api_tool.go
+++ b/nvim/api_tool.go
@@ -438,9 +438,9 @@ var nvimTypes = map[string]string{
 	"string":        "String",
 	"float64":       "Float",
 
-	"ClientType":   "String",
-	"Process":      "Object",
-	"*UserCommand": "Object",
+	"ClientType":  "String",
+	"Process":     "Object",
+	"UserCommand": "Object",
 
 	"Channel":                     "Dictionary",
 	"*Channel":                    "Dictionary",


### PR DESCRIPTION
nvim: fix UserCommand to non pointer on nvimTypes.