### PR TITLE
nvim: add ExitCode function

### DIFF
--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -94,6 +94,15 @@ func (v *Nvim) Close() error {
 	return err
 }
 
+// ExitCode returns the exit code of the exited nvim process.
+func (v *Nvim) ExitCode() int {
+	if v.cmd.ProcessState == nil {
+		return -1
+	}
+
+	return v.cmd.ProcessState.ExitCode()
+}
+
 // New creates an Nvim client. When connecting to Nvim over stdio, use stdin as
 // r and stdout as w and c, When connecting to Nvim over a network connection,
 // use the connection for r, w and c.


### PR DESCRIPTION
I'm working on a GUI for neovim and would like to support `:cq` in the GUI. 
For this reason, I propose a function in `Nvim` structure that returns the exitcode of `cmd`.