### PR TITLE
github/workflow: upgrade go version to go1.18 and drop 1.15 support

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -19,7 +19,7 @@ jobs:
         os:
           - ubuntu-20.04  # https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-README.md
         go-version:
-          - 1.17.x
+          - 1.18.x
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,9 +26,9 @@ jobs:
           - macos-11.0    # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
           - windows-2022  # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md
         go-version:
-          - 1.15.x
           - 1.16.x
           - 1.17.x
+          - 1.18.x
         neovim-version:
           - v0.6.1
           - nightly

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/neovim/go-client
 
-go 1.15
+go 1.18


### PR DESCRIPTION
Upgrade go version to go1.18 and drop 1.15 support.