### PR TITLE
nvim: fix ExitCode()

### DIFF
--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -96,10 +96,7 @@ func (v *Nvim) Close() error {
 
 // ExitCode returns the exit code of the exited nvim process.
 func (v *Nvim) ExitCode() int {
-	if v.cmd.ProcessState == nil {
-		return -1
-	}
-
+	v.cmd.Wait()
 	return v.cmd.ProcessState.ExitCode()
 }
 


### PR DESCRIPTION
`*ProcessState.ExitCode()` return -1 if the process hasn't exited.
This PR waits for the exit of the process to get the exit code correctly.