### PR TITLE
[#104] Set --embed flag by default to avoid hanging on RPC calls

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -1,7 +1,7 @@
 name: Pull Request Labeler
 
 on:
-  - pull_request
+  - pull_request_target
 
 jobs:
   triage:

--- a/nvim/nvim.go
+++ b/nvim/nvim.go
@@ -189,7 +189,6 @@ func ChildProcessLogf(logf func(string, ...interface{})) ChildProcessOption {
 }
 
 // ChildProcessDisableEmbed disables the --embed flag of nvim.
-// This is needed for applications to use the RPC API.
 // See: https://neovim.io/doc/user/starting.html#--embed for details.
 func ChildProcessDisableEmbed() ChildProcessOption {
 	return ChildProcessOption{func(cpos *childProcessOptions) {

--- a/nvim/nvim_test.go
+++ b/nvim/nvim_test.go
@@ -30,7 +30,6 @@ func newChildProcess(tb testing.TB, opts ...ChildProcessOption) (v *Nvim) {
 			"-u", "NONE",
 			"-n",
 			"-i", "NONE",
-			"--embed",
 			"--headless",
 		),
 		ChildProcessContext(ctx),
@@ -174,6 +173,18 @@ func TestCallWithNoArgs(t *testing.T) {
 	t.Parallel()
 
 	v := newChildProcess(t)
+
+	var wd string
+	err := v.Call("getcwd", &wd)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCallWithNoArgsWithDisabledEmbed(t *testing.T) {
+	t.Parallel()
+
+	v := newChildProcess(t, ChildProcessArgs("--embed"), ChildProcessDisableEmbed())
 
 	var wd string
 	err := v.Call("getcwd", &wd)


### PR DESCRIPTION
Identified that missing `--embed flag` was causing RPC calls to `nvim_exec_lua` to hang. See #155 

**Changes:**
1. Adjusted the implementation to set `--embed` flag by default in the `nvim.NewChildProcess` function to ensure a natural default to allow RPC calls to function correctly.
2. Provided an option to override the default behavior and disable `--embed` by setting the `nvim.ChildProcessDisableEmbed()` option.

---

Close: #104