### PR TITLE
maintenance

### DIFF
--- a/.github/labeler.yaml
+++ b/.github/labeler.yaml
@@ -1,11 +1,16 @@
 # https://github.com/actions/labeler
 ---
-
 area/ci:
-- .github/**
+  - .github/**
 
 area/msgpack:
-- msgpack/**/*.go
+  - msgpack/**/*.go
 
 area/nvim:
-- nvim/**/*.go
+  - nvim/**/*.go
+
+area/gomod:
+  - any['go.mod', 'go.sum']
+
+documentation:
+  - "**/*.md"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.x"
+          go-version: "1.21.x"
 
       - name: Install nvim binary
         uses: rhysd/action-setup-vim@v1

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,34 +14,34 @@ defaults:
 
 jobs:
   benchmark:
-    runs-on: ubuntu-22.04  # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
+    runs-on: ubuntu-22.04 # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
 
     steps:
-    - name: Set flag environment variable
-      run: |
-        echo "OS=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-        echo "GO_VERSION=$(echo ${{ matrix.go-version }} | cut -d. -f-2)" >> $GITHUB_ENV
+      - name: Set flag environment variable
+        run: |
+          echo "OS=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "GO_VERSION=$(echo ${{ matrix.go-version }} | cut -d. -f-2)" >> $GITHUB_ENV
 
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: '1.20.x'
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20.x"
 
-    - name: Install nvim binary
-      uses: rhysd/action-setup-vim@v1
-      with:
-        neovim: true
-        version: v0.9.1
+      - name: Install nvim binary
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: v0.9.4
 
-    - name: Run Benchmark
-      run: |
-        go test -v -count=3 -run=none -bench=. -benchmem -timeout=15m ./... | tee bench-${{ env.OS }}-${{ env.GO_VERSION }}.txt
+      - name: Run Benchmark
+        run: |
+          go test -v -count=3 -run=none -bench=. -benchmem -timeout=15m ./... | tee bench-${{ env.OS }}-${{ env.GO_VERSION }}.txt
 
-    - name: 'Upload benchmark Artifact'
-      uses: actions/upload-artifact@v3
-      with:
-        name: bench-${{ env.OS }}-${{ env.GO_VERSION }}.txt
-        path: bench-${{ env.OS }}-${{ env.GO_VERSION }}.txt
+      - name: "Upload benchmark Artifact"
+        uses: actions/upload-artifact@v3
+        with:
+          name: bench-${{ env.OS }}-${{ env.GO_VERSION }}.txt
+          path: bench-${{ env.OS }}-${{ env.GO_VERSION }}.txt

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,12 +6,12 @@ on:
       - main
   pull_request:
   schedule:
-    - cron: '0 20 * * *'
+    - cron: "0 20 * * *"
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04  # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
+    runs-on: ubuntu-22.04 # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
 
     permissions:
       actions: read
@@ -19,22 +19,22 @@ jobs:
       security-events: write
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: '1.20.x'
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: "1.20.x"
 
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
-      with:
-        languages: 'go'
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: "go"
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
-      env:
-        # hack for fetch dependencies when failed to go-autobuilder 'make' command
-        # https://github.com/github/codeql-go/blob/b953fe39c2cb/extractor/cli/go-autobuilder/go-autobuilder.go#L409
-        CODEQL_EXTRACTOR_GO_BUILD_COMMAND: 'true'
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        env:
+          # hack for fetch dependencies when failed to go-autobuilder 'make' command
+          # https://github.com/github/codeql-go/blob/b953fe39c2cb/extractor/cli/go-autobuilder/go-autobuilder.go#L409
+          CODEQL_EXTRACTOR_GO_BUILD_COMMAND: "true"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.20.x"
+          go-version: "1.21.x"
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -16,3 +16,4 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: ".github/labeler.yaml"
+          sync-labels: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,51 +20,51 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04  # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
-          - macos-13      # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
-          - windows-2022  # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
+          - ubuntu-22.04 # https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
+          - macos-13 # https://github.com/actions/runner-images/blob/main/images/macos/macos-13-Readme.md
+          - windows-2022 # https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md
         go-version:
           - 1.18.x
           - 1.19.x
           - 1.20.x
         neovim-version:
-          - v0.9.1
+          - v0.9.4
           - nightly
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
 
     steps:
-    - name: Set flag environment variable
-      run: |
-        echo "OS=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
-        echo "GO_VERSION=$(echo ${{ matrix.go-version }} | cut -d. -f-2)" >> $GITHUB_ENV
-        echo "NVIM_VERSION=$(if [ ${{ matrix.neovim-version }} != 'nightly' ]; then echo 'stable'; else echo 'nightly'; fi)" >> $GITHUB_ENV
+      - name: Set flag environment variable
+        run: |
+          echo "OS=$(echo ${{ runner.os }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+          echo "GO_VERSION=$(echo ${{ matrix.go-version }} | cut -d. -f-2)" >> $GITHUB_ENV
+          echo "NVIM_VERSION=$(if [ ${{ matrix.neovim-version }} != 'nightly' ]; then echo 'stable'; else echo 'nightly'; fi)" >> $GITHUB_ENV
 
-    - name: Install Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ matrix.go-version }}
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
 
-    - name: Checkout code
-      uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Install neovim binary
-      uses: rhysd/action-setup-vim@v1
-      with:
-        neovim: true
-        version: ${{ matrix.neovim-version }}
+      - name: Install neovim binary
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: ${{ matrix.neovim-version }}
 
-    - name: go vet
-      run: |
-        go vet ./...
+      - name: go vet
+        run: |
+          go vet ./...
 
-    - name: Test and take a coverage
-      run: |
-        go test -v -race -count=1 -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
+      - name: Test and take a coverage
+        run: |
+          go test -v -race -count=1 -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
 
-    - uses: codecov/codecov-action@v3
-      with:
-        file: coverage.out
-        flags: ${{ env.OS }}-${{ env.GO_VERSION }}-${{ env.NVIM_VERSION }}
-        env_vars: OS,GO_VERSION,NVIM_VERSION
+      - uses: codecov/codecov-action@v3
+        with:
+          file: coverage.out
+          flags: ${{ env.OS }}-${{ env.GO_VERSION }}-${{ env.NVIM_VERSION }}
+          env_vars: OS,GO_VERSION,NVIM_VERSION

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,7 @@ jobs:
           - 1.18.x
           - 1.19.x
           - 1.20.x
+          - 1.21.x
         neovim-version:
           - v0.9.4
           - nightly


### PR DESCRIPTION
# What has changed

- added gomod/documentation labels
- `sync-labels: true` on labeler cicd to reflect changes better after review process etc 😋 
- bumped `checkout` to @v4 
- `go-setup` to @v4 (automatic caching) 
- nvim latest version `0.9.4` (we can go for 10.x as nightly as well)
- added tests for go version 1.21.x (let me know if you want to change the `go.mod` to point to 1.21 as well)