### PR TITLE
chore: dependency updates

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -28,13 +28,13 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20.x'
+        go-version: '1.22.x'
 
     - name: Install nvim binary
       uses: rhysd/action-setup-vim@v1
       with:
         neovim: true
-        version: v0.9.1
+        version: v0.9.4
 
     - name: Run Benchmark
       run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20.x'
+        go-version: '1.22.x'
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,10 @@ jobs:
           - 1.18.x
           - 1.19.x
           - 1.20.x
+          - 1.21.x
+          - 1.22.x
         neovim-version:
-          - v0.9.1
+          - v0.9.4
           - nightly
       fail-fast: false
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/neovim/go-client
 
-go 1.18
+go 1.22


### PR DESCRIPTION
# What has changed:
- updated go mod to 1.22
- update ci tests for go versions 1.21 and 1.22
- update ci tests for nvim v0.9.4