### PR TITLE
Improve the test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,13 +55,9 @@ jobs:
         neovim: true
         version: ${{ matrix.neovim-version }}
 
-    - name: go vet
-      run: |
-        go vet ./...
-
     - name: Test and take a coverage
       run: |
-        go test -v -race -count=1 -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
+        go test -race -count=1 -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
 
     - uses: codecov/codecov-action@v3
       with:


### PR DESCRIPTION
Remove the go vet step. Because the go test command runs go vet, there's no need to run go vet separately.

Remove the verbose flag from the go test step. The verbose output provides little value and gets in the way of seeing the actual problems.