### PR TITLE
Update api

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@
 
 Neovim/go-client is a [Neovim](https://neovim.io/) client for [Go](https://golang.org/).
 
+Update API
+----------
+
+The API can be updated with the api tool.
+
+```sh
+cd nvim
+
+# The compare command indicates what functions need to be changed. The results
+# should be added to `api_def.go`.
+go run api_tool.go -compare
+
+# After applying the chages from compare to `api_def.go`, generate the `api.go`
+# and `api_deprecated.go` files.
+go generate
+```
+
 Release
 -------
 

--- a/nvim/api.go
+++ b/nvim/api.go
@@ -1501,6 +1501,24 @@ func (b *Batch) DeleteTabpageVar(tabpage Tabpage, name string) {
 	b.call("nvim_tabpage_del_var", nil, tabpage, name)
 }
 
+// TabpageSetWindow sets the current window in a tabpage.
+//
+// See: [nvim_tabpage_set_win()]
+//
+// [nvim_tabpage_set_win()]: https://neovim.io/doc/user/api.html#nvim_tabpage_set_win()
+func (v *Nvim) TabpageSetWindow(tabpage Tabpage, win Window) error {
+	return v.call("nvim_tabpage_set_win", nil, tabpage, win)
+}
+
+// TabpageSetWindow sets the current window in a tabpage.
+//
+// See: [nvim_tabpage_set_win()]
+//
+// [nvim_tabpage_set_win()]: https://neovim.io/doc/user/api.html#nvim_tabpage_set_win()
+func (b *Batch) TabpageSetWindow(tabpage Tabpage, win Window) {
+	b.call("nvim_tabpage_set_win", nil, tabpage, win)
+}
+
 // TabpageWindow gets the current window in a tabpage.
 //
 // See: [nvim_tabpage_get_win()]
@@ -2333,118 +2351,6 @@ func (b *Batch) OptionInfo(name string, opts map[string]any, opinfo *OptionInfo)
 	b.call("nvim_get_option_info2", opinfo, name, opts)
 }
 
-// SetOption sets an option value.
-//
-// See: [nvim_set_option()]
-//
-// [nvim_set_option()]: https://neovim.io/doc/user/api.html#nvim_set_option()
-func (v *Nvim) SetOption(name string, value any) error {
-	return v.call("nvim_set_option", nil, name, value)
-}
-
-// SetOption sets an option value.
-//
-// See: [nvim_set_option()]
-//
-// [nvim_set_option()]: https://neovim.io/doc/user/api.html#nvim_set_option()
-func (b *Batch) SetOption(name string, value any) {
-	b.call("nvim_set_option", nil, name, value)
-}
-
-// Option gets an option value string.
-//
-// See: [nvim_get_option()]
-//
-// [nvim_get_option()]: https://neovim.io/doc/user/api.html#nvim_get_option()
-func (v *Nvim) Option(name string, result any) error {
-	return v.call("nvim_get_option", result, name)
-}
-
-// Option gets an option value string.
-//
-// See: [nvim_get_option()]
-//
-// [nvim_get_option()]: https://neovim.io/doc/user/api.html#nvim_get_option()
-func (b *Batch) Option(name string, result any) {
-	b.call("nvim_get_option", &result, name)
-}
-
-// BufferOption gets a buffer option value.
-//
-// See: [nvim_buf_get_option()]
-//
-// [nvim_buf_get_option()]: https://neovim.io/doc/user/api.html#nvim_buf_get_option()
-func (v *Nvim) BufferOption(buffer Buffer, name string, result any) error {
-	return v.call("nvim_buf_get_option", result, buffer, name)
-}
-
-// BufferOption gets a buffer option value.
-//
-// See: [nvim_buf_get_option()]
-//
-// [nvim_buf_get_option()]: https://neovim.io/doc/user/api.html#nvim_buf_get_option()
-func (b *Batch) BufferOption(buffer Buffer, name string, result any) {
-	b.call("nvim_buf_get_option", &result, buffer, name)
-}
-
-// SetBufferOption sets a buffer option value.
-//
-// Passing nil as value arg to deletes the option (only works if there's a global fallback).
-//
-// See: [nvim_buf_set_option()]
-//
-// [nvim_buf_set_option()]: https://neovim.io/doc/user/api.html#nvim_buf_set_option()
-func (v *Nvim) SetBufferOption(buffer Buffer, name string, value any) error {
-	return v.call("nvim_buf_set_option", nil, buffer, name, value)
-}
-
-// SetBufferOption sets a buffer option value.
-//
-// Passing nil as value arg to deletes the option (only works if there's a global fallback).
-//
-// See: [nvim_buf_set_option()]
-//
-// [nvim_buf_set_option()]: https://neovim.io/doc/user/api.html#nvim_buf_set_option()
-func (b *Batch) SetBufferOption(buffer Buffer, name string, value any) {
-	b.call("nvim_buf_set_option", nil, buffer, name, value)
-}
-
-// WindowOption gets a window option value.
-//
-// See: [nvim_win_get_option()]
-//
-// [nvim_win_get_option()]: https://neovim.io/doc/user/api.html#nvim_win_get_option()
-func (v *Nvim) WindowOption(window Window, name string, result any) error {
-	return v.call("nvim_win_get_option", result, window, name)
-}
-
-// WindowOption gets a window option value.
-//
-// See: [nvim_win_get_option()]
-//
-// [nvim_win_get_option()]: https://neovim.io/doc/user/api.html#nvim_win_get_option()
-func (b *Batch) WindowOption(window Window, name string, result any) {
-	b.call("nvim_win_get_option", &result, window, name)
-}
-
-// SetWindowOption sets a window option value. Passing "nil" as value deletes the option(only works if there's a global fallback).
-//
-// See: [nvim_win_set_option()]
-//
-// [nvim_win_set_option()]: https://neovim.io/doc/user/api.html#nvim_win_set_option()
-func (v *Nvim) SetWindowOption(window Window, name string, value any) error {
-	return v.call("nvim_win_set_option", nil, window, name, value)
-}
-
-// SetWindowOption sets a window option value. Passing "nil" as value deletes the option(only works if there's a global fallback).
-//
-// See: [nvim_win_set_option()]
-//
-// [nvim_win_set_option()]: https://neovim.io/doc/user/api.html#nvim_win_set_option()
-func (b *Batch) SetWindowOption(window Window, name string, value any) {
-	b.call("nvim_win_set_option", nil, window, name, value)
-}
-
 // AttachUI registers the client as a remote UI. After this method is called,
 // the client will receive redraw notifications.
 //
@@ -2541,6 +2447,24 @@ func (v *Nvim) TryResizeUI(width int, height int) error {
 // [nvim_ui_try_resize()]: https://neovim.io/doc/user/api.html#nvim_ui_try_resize()
 func (b *Batch) TryResizeUI(width int, height int) {
 	b.call("nvim_ui_try_resize", nil, width, height)
+}
+
+// UITermEvent sends a terminal event to the UI.
+//
+// See: [nvim_ui_term_event()]
+//
+// [nvim_ui_term_event()]: https://neovim.io/doc/user/api.html#nvim_ui_term_event()
+func (v *Nvim) UITermEvent(event string, value any) error {
+	return v.call("nvim_ui_term_event", nil, event, value)
+}
+
+// UITermEvent sends a terminal event to the UI.
+//
+// See: [nvim_ui_term_event()]
+//
+// [nvim_ui_term_event()]: https://neovim.io/doc/user/api.html#nvim_ui_term_event()
+func (b *Batch) UITermEvent(event string, value any) {
+	b.call("nvim_ui_term_event", nil, event, value)
 }
 
 // SetUIOption sets a UI option.
@@ -2798,6 +2722,25 @@ func (v *Nvim) HLIDByName(name string) (hlID int, err error) {
 // [nvim_get_hl_id_by_name()]: https://neovim.io/doc/user/api.html#nvim_get_hl_id_by_name()
 func (b *Batch) HLIDByName(name string, hlID *int) {
 	b.call("nvim_get_hl_id_by_name", hlID, name)
+}
+
+// GetHighlightNamespace gets highlight namespace.
+//
+// See: [nvim_get_hl_ns()]
+//
+// [nvim_get_hl_ns()]: https://neovim.io/doc/user/api.html#nvim_get_hl_ns()
+func (v *Nvim) GetHighlightNamespace(opts map[string]any) (ns int, err error) {
+	err = v.call("nvim_get_hl_ns", &ns, opts)
+	return ns, err
+}
+
+// GetHighlightNamespace gets highlight namespace.
+//
+// See: [nvim_get_hl_ns()]
+//
+// [nvim_get_hl_ns()]: https://neovim.io/doc/user/api.html#nvim_get_hl_ns()
+func (b *Batch) GetHighlightNamespace(opts map[string]any, ns *int) {
+	b.call("nvim_get_hl_ns", ns, opts)
 }
 
 // SetHighlight sets a highlight group.
@@ -4890,6 +4833,25 @@ func (v *Nvim) SetWindowWidth(window Window, width int) error {
 // [nvim_win_set_width()]: https://neovim.io/doc/user/api.html#nvim_win_set_width()
 func (b *Batch) SetWindowWidth(window Window, width int) {
 	b.call("nvim_win_set_width", nil, window, width)
+}
+
+// WindowTextHeight calculates the height of window text.
+//
+// See: [nvim_win_text_height()]
+//
+// [nvim_win_text_height()]: https://neovim.io/doc/user/api.html#nvim_win_text_height()
+func (v *Nvim) WindowTextHeight(window Window, opts map[string]any) (result map[string]any, err error) {
+	err = v.call("nvim_win_text_height", &result, window, opts)
+	return result, err
+}
+
+// WindowTextHeight calculates the height of window text.
+//
+// See: [nvim_win_text_height()]
+//
+// [nvim_win_text_height()]: https://neovim.io/doc/user/api.html#nvim_win_text_height()
+func (b *Batch) WindowTextHeight(window Window, opts map[string]any, result *map[string]any) {
+	b.call("nvim_win_text_height", result, window, opts)
 }
 
 // WindowVar gets a window-scoped (w:) variable.

--- a/nvim/api_def.go
+++ b/nvim/api_def.go
@@ -589,6 +589,11 @@ func DeleteTabpageVar(tabpage Tabpage, name string) {
 	name(nvim_tabpage_del_var)
 }
 
+// TabpageSetWindow sets the current window in a tabpage.
+func TabpageSetWindow(tabpage Tabpage, win Window) {
+	name(nvim_tabpage_set_win)
+}
+
 // TabpageWindow gets the current window in a tabpage.
 func TabpageWindow(tabpage Tabpage) Window {
 	name(nvim_tabpage_get_win)
@@ -951,16 +956,19 @@ func OptionInfo(name string, opts map[string]any) (opinfo OptionInfo) {
 // SetOption sets an option value.
 func SetOption(name string, value any) {
 	name(nvim_set_option)
+	deprecatedSince(11)
 }
 
 // Option gets an option value string.
 func Option(name string) (option any) {
 	name(nvim_get_option)
+	deprecatedSince(11)
 }
 
 // BufferOption gets a buffer option value.
 func BufferOption(buffer Buffer, name string) (value any) {
 	name(nvim_buf_get_option)
+	deprecatedSince(11)
 }
 
 // SetBufferOption sets a buffer option value.
@@ -968,16 +976,19 @@ func BufferOption(buffer Buffer, name string) (value any) {
 // Passing nil as value arg to deletes the option (only works if there's a global fallback).
 func SetBufferOption(buffer Buffer, name string, value any) {
 	name(nvim_buf_set_option)
+	deprecatedSince(11)
 }
 
 // WindowOption gets a window option value.
 func WindowOption(window Window, name string) (value any) {
 	name(nvim_win_get_option)
+	deprecatedSince(11)
 }
 
 // SetWindowOption sets a window option value. Passing "nil" as value deletes the option(only works if there's a global fallback).
 func SetWindowOption(window Window, name string, value any) {
 	name(nvim_win_set_option)
+	deprecatedSince(11)
 }
 
 // ui.c
@@ -1013,6 +1024,11 @@ func DetachUI() {
 // Nvim will send a redraw request to resize.
 func TryResizeUI(width, height int) {
 	name(nvim_ui_try_resize)
+}
+
+// UITermEvent sends a terminal event to the UI.
+func UITermEvent(event string, value any) {
+	name(nvim_ui_term_event)
 }
 
 // SetUIOption sets a UI option.
@@ -1135,6 +1151,12 @@ func HLByName(name string, rgb bool) (highlight HLAttrs) {
 	returnPtr()
 	deprecatedSince(9)
 }
+
+// GetHighlightNamespace gets highlight namespace.
+func GetHighlightNamespace(opts map[string]any) (ns int) {
+	name(nvim_get_hl_ns)
+}
+
 
 // SetHighlight sets a highlight group.
 //
@@ -1902,6 +1924,11 @@ func WindowWidth(window Window) (width int) {
 // SetWindowWidth Sets the window width. This will only succeed if the screen is split vertically.
 func SetWindowWidth(window Window, width int) {
 	name(nvim_win_set_width)
+}
+
+// WindowTextHeight calculates the height of window text.
+func WindowTextHeight(window Window, opts map[string]any) (result map[string]any) {
+	name(nvim_win_text_height)
 }
 
 // WindowVar gets a window-scoped (w:) variable.

--- a/nvim/api_deprecated.go
+++ b/nvim/api_deprecated.go
@@ -186,6 +186,118 @@ func (b *Batch) SetBufferVirtualText(buffer Buffer, nsID int, line int, chunks [
 	b.call("nvim_buf_set_virtual_text", id, buffer, nsID, line, chunks, opts)
 }
 
+// SetOption sets an option value.
+//
+// See: [nvim_set_option()]
+//
+// [nvim_set_option()]: https://neovim.io/doc/user/api.html#nvim_set_option()
+func (v *Nvim) SetOption(name string, value any) error {
+	return v.call("nvim_set_option", nil, name, value)
+}
+
+// SetOption sets an option value.
+//
+// See: [nvim_set_option()]
+//
+// [nvim_set_option()]: https://neovim.io/doc/user/api.html#nvim_set_option()
+func (b *Batch) SetOption(name string, value any) {
+	b.call("nvim_set_option", nil, name, value)
+}
+
+// Option gets an option value string.
+//
+// See: [nvim_get_option()]
+//
+// [nvim_get_option()]: https://neovim.io/doc/user/api.html#nvim_get_option()
+func (v *Nvim) Option(name string, result any) error {
+	return v.call("nvim_get_option", result, name)
+}
+
+// Option gets an option value string.
+//
+// See: [nvim_get_option()]
+//
+// [nvim_get_option()]: https://neovim.io/doc/user/api.html#nvim_get_option()
+func (b *Batch) Option(name string, result any) {
+	b.call("nvim_get_option", &result, name)
+}
+
+// BufferOption gets a buffer option value.
+//
+// See: [nvim_buf_get_option()]
+//
+// [nvim_buf_get_option()]: https://neovim.io/doc/user/api.html#nvim_buf_get_option()
+func (v *Nvim) BufferOption(buffer Buffer, name string, result any) error {
+	return v.call("nvim_buf_get_option", result, buffer, name)
+}
+
+// BufferOption gets a buffer option value.
+//
+// See: [nvim_buf_get_option()]
+//
+// [nvim_buf_get_option()]: https://neovim.io/doc/user/api.html#nvim_buf_get_option()
+func (b *Batch) BufferOption(buffer Buffer, name string, result any) {
+	b.call("nvim_buf_get_option", &result, buffer, name)
+}
+
+// SetBufferOption sets a buffer option value.
+//
+// Passing nil as value arg to deletes the option (only works if there's a global fallback).
+//
+// See: [nvim_buf_set_option()]
+//
+// [nvim_buf_set_option()]: https://neovim.io/doc/user/api.html#nvim_buf_set_option()
+func (v *Nvim) SetBufferOption(buffer Buffer, name string, value any) error {
+	return v.call("nvim_buf_set_option", nil, buffer, name, value)
+}
+
+// SetBufferOption sets a buffer option value.
+//
+// Passing nil as value arg to deletes the option (only works if there's a global fallback).
+//
+// See: [nvim_buf_set_option()]
+//
+// [nvim_buf_set_option()]: https://neovim.io/doc/user/api.html#nvim_buf_set_option()
+func (b *Batch) SetBufferOption(buffer Buffer, name string, value any) {
+	b.call("nvim_buf_set_option", nil, buffer, name, value)
+}
+
+// WindowOption gets a window option value.
+//
+// See: [nvim_win_get_option()]
+//
+// [nvim_win_get_option()]: https://neovim.io/doc/user/api.html#nvim_win_get_option()
+func (v *Nvim) WindowOption(window Window, name string, result any) error {
+	return v.call("nvim_win_get_option", result, window, name)
+}
+
+// WindowOption gets a window option value.
+//
+// See: [nvim_win_get_option()]
+//
+// [nvim_win_get_option()]: https://neovim.io/doc/user/api.html#nvim_win_get_option()
+func (b *Batch) WindowOption(window Window, name string, result any) {
+	b.call("nvim_win_get_option", &result, window, name)
+}
+
+// SetWindowOption sets a window option value. Passing "nil" as value deletes the option(only works if there's a global fallback).
+//
+// See: [nvim_win_set_option()]
+//
+// [nvim_win_set_option()]: https://neovim.io/doc/user/api.html#nvim_win_set_option()
+func (v *Nvim) SetWindowOption(window Window, name string, value any) error {
+	return v.call("nvim_win_set_option", nil, window, name, value)
+}
+
+// SetWindowOption sets a window option value. Passing "nil" as value deletes the option(only works if there's a global fallback).
+//
+// See: [nvim_win_set_option()]
+//
+// [nvim_win_set_option()]: https://neovim.io/doc/user/api.html#nvim_win_set_option()
+func (b *Batch) SetWindowOption(window Window, name string, value any) {
+	b.call("nvim_win_set_option", nil, window, name, value)
+}
+
 // HLByID gets a highlight definition by name.
 //
 // hlID is the highlight id as returned by HLIDByName.


### PR DESCRIPTION
here's the output from the compare
```
❯ go run api_tool.go -compare
> nvim_get_hl_ns(opts Dictionary) Integer { name(nvim_get_hl_ns) }
> nvim_tabpage_set_win(tabpage Tabpage, win Window) void { name(nvim_tabpage_set_win) }
> nvim_ui_term_event(event String, value Object) void { name(nvim_ui_term_event) }
> nvim_win_text_height(window Window, opts Dictionary) Dictionary { name(nvim_win_text_height) }
----
< nvim_buf_get_option(buffer Buffer, name String) Object { name(nvim_buf_get_option) }
> nvim_buf_get_option(buffer Buffer, name String) Object { name(nvim_buf_get_option); deprecatedSince(11); }
----
< nvim_buf_set_option(buffer Buffer, name String, value Object) void { name(nvim_buf_set_option) }
> nvim_buf_set_option(buffer Buffer, name String, value Object) void { name(nvim_buf_set_option); deprecatedSince(11); }
----
< nvim_get_option(name String) Object { name(nvim_get_option) }
> nvim_get_option(name String) Object { name(nvim_get_option); deprecatedSince(11); }
----
< nvim_set_option(name String, value Object) void { name(nvim_set_option) }
> nvim_set_option(name String, value Object) void { name(nvim_set_option); deprecatedSince(11); }
----
< nvim_win_get_option(window Window, name String) Object { name(nvim_win_get_option) }
> nvim_win_get_option(window Window, name String) Object { name(nvim_win_get_option); deprecatedSince(11); }
----
< nvim_win_set_option(window Window, name String, value Object) void { name(nvim_win_set_option) }
> nvim_win_set_option(window Window, name String, value Object) void { name(nvim_win_set_option); deprecatedSince(11); }
```

I mostly just took a stab at this, I'm not sure if there is a better process, but I put down the steps I took in the readme. I was waiting until #184 was merged since it's harder to validate regressions, but the tests are passing locally.